### PR TITLE
Method not found because of wrong method name

### DIFF
--- a/src/Google/Service/Webmasters.php
+++ b/src/Google/Service/Webmasters.php
@@ -181,7 +181,7 @@ class Google_Service_Webmasters extends Google_Service
                   'required' => true,
                 ),
               ),
-            ),'list' => array(
+            ),'listSites' => array(
               'path' => 'sites',
               'httpMethod' => 'GET',
               'parameters' => array(),


### PR DESCRIPTION
Conflict method name with Webmasters/Resource/Sites.php

list() is given in Webmasters.php instead of listSites()