### PR TITLE
Remove incorrect entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 vendor
 composer.lock
-src/Google/Service/Compute/HTTPHealthCheck.php
-src/Google/Service/Compute/HTTPSHealthCheck.php


### PR DESCRIPTION
It will be still broken, but we should remove them, right?