### PR TITLE
Update Tag.php - fix doc of setParameter method

### DIFF
--- a/src/Google/Service/TagManager/Tag.php
+++ b/src/Google/Service/TagManager/Tag.php
@@ -128,7 +128,7 @@ class Google_Service_TagManager_Tag extends Google_Collection
     return $this->notes;
   }
   /**
-   * @param Google_Service_TagManager_Parameter
+   * @param [Google_Service_TagManager_Parameter]
    */
   public function setParameter($parameter)
   {


### PR DESCRIPTION
The phpdoc suggest to pass a Google_Service_TagManager_Parameter object to the Google_Service_TagManager_Tag::setParameter(). But this is wrong, the method require an array containing a Google_Service_TagManager_Parameter Object.