### PR TITLE
fix(analytics): fix typing for GaData#columnHeaders

### DIFF
--- a/src/Google/Service/Analytics/GaData.php
+++ b/src/Google/Service/Analytics/GaData.php
@@ -41,14 +41,14 @@ class Google_Service_Analytics_GaData extends Google_Collection
   public $totalsForAllResults;
 
   /**
-   * @param Google_Service_Analytics_GaDataColumnHeaders
+   * @param Google_Service_Analytics_GaDataColumnHeaders[]
    */
   public function setColumnHeaders($columnHeaders)
   {
     $this->columnHeaders = $columnHeaders;
   }
   /**
-   * @return Google_Service_Analytics_GaDataColumnHeaders
+   * @return Google_Service_Analytics_GaDataColumnHeaders[]
    */
   public function getColumnHeaders()
   {


### PR DESCRIPTION
Actually, `GaData#columnHeaders` is an array of `Google_Service_Analytics_GaDataColumnHeaders`.
This PR fix the typing of `getColumnHeaders()` and `setColumnHeaders()` methods.  

![ga_data](https://user-images.githubusercontent.com/2103975/53640872-a1f69f00-3c2d-11e9-8219-5fa3811bfa1a.png)
