### PR TITLE
Typecast to an array :)

### DIFF
--- a/src/Google/Service/Calendar/Resource/Colors.php
+++ b/src/Google/Service/Calendar/Resource/Colors.php
@@ -34,7 +34,7 @@ class Google_Service_Calendar_Resource_Colors extends Google_Service_Resource
   public function get($optParams = array())
   {
     $params = array();
-    $params = array_merge($params, $optParams);
+    $params = array_merge($params, (array) $optParams);
     return $this->call('get', array($params), "Google_Service_Calendar_Colors");
   }
 }


### PR DESCRIPTION
When calling ->get(..) without parameters, PHP will default the empty array to null

One way of calling it without this, would be to call `get([])` with an empty array.
That seems like a bad behavior.

Just  a neat little trick is to let the user call the function with `null` and then just typecast the array.