### PR TITLE
[Youtube Live Streaming] Provide an easy and clear way to unbind all streams from a broadcast

### DIFF
--- a/src/Google/Service/YouTube/Resource/LiveBroadcasts.php
+++ b/src/Google/Service/YouTube/Resource/LiveBroadcasts.php
@@ -83,6 +83,23 @@ class Google_Service_YouTube_Resource_LiveBroadcasts extends Google_Service_Reso
     return $this->call('bind', array($params), "Google_Service_YouTube_LiveBroadcast");
   }
   /**
+   * Removes broadcast's existing bindings.
+   * (liveBroadcasts.bind)
+   *
+   * @param string $id The id parameter specifies the unique ID of the broadcast
+   * that is being bound to a video stream.
+   * @param string $part The part parameter specifies a comma-separated list of
+   * one or more liveBroadcast resource properties that the API response will
+   * include. The part names that you can include in the parameter value are id,
+   * snippet, contentDetails, and status.
+   *
+   * @return Google_Service_YouTube_LiveBroadcast
+   */
+  public function unbind($id, $part)
+  {
+      return $this->bind($id, $part);
+  }
+  /**
    * Controls the settings for a slate that can be displayed in the broadcast
    * stream. (liveBroadcasts.control)
    *


### PR DESCRIPTION
Hello,
In a project i'm working on currently, in order to unbind streams from a broadcast, we had to do :

```php
$this->youtubeService->liveBroadcasts->bind(
    $liveViewing->getBroadcastId(),
    'id'
);
```

I didn't like too much the fact to have to call the `bind` method to unbind. I felt it like counter intuitive and a bit magic.
That's a reason i would like to introduce a new way to do it.

Thanks a lot,