### PR TITLE
add text/plain content type Doubleclick getFile

### DIFF
--- a/src/Google/Service/Doubleclicksearch/Resource/Reports.php
+++ b/src/Google/Service/Doubleclicksearch/Resource/Reports.php
@@ -62,7 +62,7 @@ class Google_Service_Doubleclicksearch_Resource_Reports extends Google_Service_R
   {
     $params = array('reportId' => $reportId, 'reportFragment' => $reportFragment);
     $params = array_merge($params, $optParams);
-    return $this->call('getFile', array($params));
+    return $this->call('getFile', array($params), null, 'text/plain');
   }
   /**
    * Inserts a report request into the reporting system. (reports.request)


### PR DESCRIPTION
This PR is stricly tied with this one: https://github.com/googleapis/google-api-php-client/pull/1895

getFile method is not working because of a content-type issue. It needs `text/plain`.

You should tag this a version of `google-api-php-client-services` and then use this tag in composer.json of `google-api-php-client`