### PR TITLE
[People API] Use personFields instead of deprecated requestMask.includeField

### DIFF
--- a/src/Google/Service/People.php
+++ b/src/Google/Service/People.php
@@ -89,7 +89,7 @@ class Google_Service_People extends Google_Service
                   'type' => 'string',
                   'required' => true,
                 ),
-                'requestMask.includeField' => array(
+                'personFields' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),
@@ -98,7 +98,7 @@ class Google_Service_People extends Google_Service
               'path' => 'v1/people:batchGet',
               'httpMethod' => 'GET',
               'parameters' => array(
-                'requestMask.includeField' => array(
+                'personFields' => array(
                   'location' => 'query',
                   'type' => 'string',
                 ),


### PR DESCRIPTION
RequestMask was [deprecated](https://developers.google.com/people/api/rest/v1/RequestMask), instead [people->get](https://developers.google.com/people/api/rest/v1/people/get) requires the `personFields` parameter now.

This pull request updates the Google_Services_People class to understand the personFields parameter.