### PR TITLE
feat: require PHP 5.6, add PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 5.4, 5.5, 5.6, "7.0", 7.1, 7.2, 7.3, 7.4 ]
+                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0" ]
         name: PHP ${{matrix.php }} Unit Test
         steps:
             - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5"
+        "phpunit/phpunit": "^5.7||^8.5.13"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5"

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -18,7 +18,9 @@
  * under the License.
  */
 
-class Google_Service_ServiceTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Google_Service_ServiceTest extends TestCase
 {
   /**
    * @dataProvider serviceProvider


### PR DESCRIPTION
 - Bumps minimum required PHP version to 5.6 for compatibility with https://github.com/googleapis/google-api-php-client
 - Adds compatibility for PHP 8.0

This is in preparation for #363, as we want to bump the version before making the change