### PR TITLE
fix Class 'Google\Service\Tokeninfo' not found error

### DIFF
--- a/src/Oauth2.php
+++ b/src/Oauth2.php
@@ -18,7 +18,7 @@
 namespace Google\Service;
 
 use Google\Client;
-use Google\Service\Tokeninfo;
+use Google\Service\Oauth2\Tokeninfo;
 
 /**
  * Service definition for Oauth2 (v2).

--- a/src/Oauth2.php
+++ b/src/Oauth2.php
@@ -18,6 +18,7 @@
 namespace Google\Service;
 
 use Google\Client;
+use Google\Service\Tokeninfo;
 
 /**
  * Service definition for Oauth2 (v2).


### PR DESCRIPTION
add missing use declaration to src/Oauth2.php

closes #392 