### PR TITLE
fix - import class Tokeninfo

### DIFF
--- a/src/Oauth2.php
+++ b/src/Oauth2.php
@@ -18,6 +18,7 @@
 namespace Google\Service;
 
 use Google\Client;
+use Google\Service\Oauth2\Tokeninfo;
 
 /**
  * Service definition for Oauth2 (v2).


### PR DESCRIPTION
I found an issue "Class 'Google\\Service\\Tokeninfo' not found."

The class `Tokeninfo` exists within the namespace `Google\Service\Oauth2`.
But the class `Oauth2` exists within the namespace `Google\Service`.

So, it looks like `use Google\Service\Oauth2\Tokeninfo;` needs to be added to the `Oauth2`.