### PR TITLE
Drop EOL-versions of PHP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0" ]
+                php: [ 7.4, "8.0" ]
         name: PHP ${{matrix.php }} Unit Test
         steps:
             - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7||^8.5.13"

--- a/tests/VendorTest.php
+++ b/tests/VendorTest.php
@@ -33,9 +33,9 @@ class VendorTest extends TestCase
     {
         if (
             'dev-main' === $apiClientVersion
-            && version_compare(PHP_VERSION, '5.6', '<')
+            && version_compare(PHP_VERSION, '7.4', '<')
         ) {
-            self::markTestSkipped('dev-main of google/apiclient can only run on 5.6');
+            self::markTestSkipped('dev-main of google/apiclient can only run on 7.4');
         }
         if ('true' === getenv('SKIP_VENDOR_TESTS')) {
             self::markTestSkipped('Explicitly skipping the vendor tests');


### PR DESCRIPTION
See https://github.com/googleapis/google-api-php-client/pull/2167 