### PR TITLE
Add Enum Classes for Enum Properties & Parameters

### DIFF
--- a/generator/src/googleapis/codegen/generator.py
+++ b/generator/src/googleapis/codegen/generator.py
@@ -328,8 +328,8 @@ class TemplateGenerator(object):
     Raises:
       ValueError: If the template_file_name does not match the call_info data.
     """
-    path_and_var_regex = r'%s([a-z][A-Za-z]*)___' % path_prefix
-    match_obj = re.compile(path_and_var_regex).match(template_file_name)
+    path_and_var_regex = re.compile(r'%s([a-z][A-Za-z]*)___' % path_prefix)
+    match_obj = path_and_var_regex.match(template_file_name)
     if not match_obj:
       raise ValueError(
           'file names which match path item for GenerateListOfFiles must'
@@ -340,12 +340,20 @@ class TemplateGenerator(object):
       file_name = template_file_name.replace(
           file_name_piece_to_replace, element.values[variable_name])
       name_in_zip = file_name[:-5]  # strip '.tmpl'
+
       if file_filter and not file_filter(None, name_in_zip):
         continue
+
+      element_relative_path = relative_path
+      for match_obj in path_and_var_regex.finditer(relative_path):
+        variable_name = match_obj.group(1)
+        element_relative_path = element_relative_path.replace(
+            path_prefix + variable_name + '___', element.values[variable_name])
+
       d = dict(variables)
       d[call_info[0]] = element
       self.RenderTemplateToFile(
-          template_path, d, package, os.path.join(relative_path, name_in_zip))
+          template_path, d, package, os.path.join(element_relative_path, name_in_zip))
 
 
 class ToolInformation(UseableInTemplates):

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/Enums/___enums_namespaceName___/___enums_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/Enums/___enums_namespaceName___/___enums_className___.php.tmpl
@@ -1,0 +1,6 @@
+<?php
+{% language php %}{% copyright_block %}
+
+namespace {{ api.ownerName }}\Service\{{ api.className }}\Enums\{{ enum.namespaceName }};
+
+{% call_template _enum enum=enum %}

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/Enums/___topLevelEnums_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/Enums/___topLevelEnums_className___.php.tmpl
@@ -1,0 +1,6 @@
+<?php
+{% language php %}{% copyright_block %}
+
+namespace {{ api.ownerName }}\Service\{{ api.className }}\Enums;
+
+{% call_template _enum enum=enum %}

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
@@ -29,6 +29,7 @@ class {{ model.className }} extends {% if model.superClass %}{{ model.superClass
  {% if property.annotationType %}
   /**
    * @var {{ property.annotationType }}{% if property.dataType == "array" or property.dataType == "map" %}[]{% endif %}
+{% if property.enum %}   * @see {{ api.ownerName }}\Service\{{ api.className }}\Enums\{{ property.enum.namespaceName }}\{{ property.enum.className }}{% endif %}
    */
  {% endif %}
   public ${{ property.memberName }};

--- a/generator/src/googleapis/codegen/languages/php/default/templates/_enum.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/_enum.tmpl
@@ -1,0 +1,13 @@
+final class {{ enum.className }}
+{
+{% filter noblanklines %}
+{% indent %}{% for element in enum.elements %}
+/**
+ * {% if element.description %}{{ element.description }}{% endif %}
+ * @var string
+ */
+const {{ element.constantName|upper }} = "{{ element.value }}";
+{% endfor %}
+{% endindent %}
+{% endfilter %}
+}

--- a/generator/src/googleapis/codegen/php_generator.py
+++ b/generator/src/googleapis/codegen/php_generator.py
@@ -395,6 +395,7 @@ class EnumVisitor(object):
         if isinstance(api_object, Property) and self._is_enum(api_object.data_type):
             target = copy.deepcopy(api_object.data_type)
             target.SetTemplateValue('namespaceName', api_object.schema.GetTemplateValue('className'))
+            api_object.SetTemplateValue('enum', target)
             self.properties_with_enums.append(target)
 
     def _is_enum(self, api_object):

--- a/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
@@ -101,6 +101,35 @@ class EccoDomaniIeri extends \Google\Service
 // Adding a class alias for backwards compatibility with the previous class name.
 class_alias(EccoDomaniIeri::class, 'Google_Service_EccoDomaniIeri');
 === end: EccoDomaniIeri.php
+=== begin: EccoDomaniIeri/Enums/Alt.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\EccoDomaniIeri\Enums;
+
+final class Alt
+{
+  /**
+   * Responses with Content-Type of application/json
+   * @var string
+   */
+  const JSON = "json";
+}
+=== end: EccoDomaniIeri/Enums/Alt.php
 === begin: EccoDomaniIeri/HelloGreeting.php
 <?php
 /*

--- a/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
@@ -101,6 +101,35 @@ class EccoDomaniIeri extends \Google\Service
 // Adding a class alias for backwards compatibility with the previous class name.
 class_alias(EccoDomaniIeri::class, 'NASA_Service_EccoDomaniIeri');
 === end: EccoDomaniIeri.php
+=== begin: EccoDomaniIeri/Enums/Alt.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace NASA\Service\EccoDomaniIeri\Enums;
+
+final class Alt
+{
+  /**
+   * Responses with Content-Type of application/json
+   * @var string
+   */
+  const JSON = "json";
+}
+=== end: EccoDomaniIeri/Enums/Alt.php
 === begin: EccoDomaniIeri/HelloGreeting.php
 <?php
 /*

--- a/generator/tests/testdata/golden/php/default/enums.golden
+++ b/generator/tests/testdata/golden/php/default/enums.golden
@@ -1,0 +1,265 @@
+=== begin: Enums.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service;
+
+use Google\Client;
+
+/**
+ * Service definition for Enums (v1).
+ *
+ * <p>
+ * verifying the PHP float primitive type</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class Enums extends \Google\Service
+{
+  /** A non googleapis.com scope. */
+  const MAIL_GOOGLE_COM =
+      "https://mail.google.com/";
+  /** a product level scope. */
+  const PRODUCT =
+      "https://www.googleapis.com/auth/product";
+  /** A typical scope. */
+  const USERINFO_EMAIL =
+      "https://www.googleapis.com/auth/userinfo.email";
+
+  public $enums;
+
+  /**
+   * Constructs the internal representation of the Enums service.
+   *
+   * @param Client|array $clientOrConfig The client used to deliver requests, or a
+   *                                     config array to pass to a new Client instance.
+   * @param string $rootUrl The root URL used for requests to the service.
+   */
+  public function __construct($clientOrConfig = [], $rootUrl = null)
+  {
+    parent::__construct($clientOrConfig);
+    $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->servicePath = 'php_float_type/v1/';
+    $this->version = 'v1';
+    $this->serviceName = 'enums';
+
+    $this->enums = new Enums\Resource\Enums(
+        $this,
+        $this->serviceName,
+        'enums',
+        [
+          'methods' => [
+            'get' => [
+              'path' => 'enums',
+              'httpMethod' => 'GET',
+              'parameters' => [],
+            ],
+          ]
+        ]
+    );
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Enums::class, 'Google_Service_Enums');
+=== end: Enums.php
+=== begin: Enums/Enums/ObjectWithEnumProperty/PropName.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\Enums\Enums\ObjectWithEnumProperty;
+
+final class PropName
+{
+  /**
+   * meaningful api docs here
+   * @var string
+   */
+  const ONE = "one";
+  /**
+   * and here too!
+   * @var string
+   */
+  const TWO = "two";
+}
+=== end: Enums/Enums/ObjectWithEnumProperty/PropName.php
+=== begin: Enums/Enums/SimpleEnum.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\Enums\Enums;
+
+final class SimpleEnum
+{
+  /**
+   * first
+   * @var string
+   */
+  const ONE = "one";
+  /**
+   * second
+   * @var string
+   */
+  const TWO = "two";
+}
+=== end: Enums/Enums/SimpleEnum.php
+=== begin: Enums/ObjectWithEnumProperty.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\Enums;
+
+class ObjectWithEnumProperty extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $notEnum;
+  /**
+   * @var string
+   */
+  public $propName;
+
+  /**
+   * @param string
+   */
+  public function setNotEnum($notEnum)
+  {
+    $this->notEnum = $notEnum;
+  }
+  /**
+   * @return string
+   */
+  public function getNotEnum()
+  {
+    return $this->notEnum;
+  }
+  /**
+   * @param string
+   */
+  public function setPropName($propName)
+  {
+    $this->propName = $propName;
+  }
+  /**
+   * @return string
+   */
+  public function getPropName()
+  {
+    return $this->propName;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ObjectWithEnumProperty::class, 'Google_Service_Enums_ObjectWithEnumProperty');
+=== end: Enums/ObjectWithEnumProperty.php
+=== begin: Enums/Resource/Enums.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\Enums\Resource;
+
+use Google\Service\Enums\ObjectWithEnums;
+
+/**
+ * The "enums" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $enumsService = new Google\Service\Enums(...);
+ *   $enums = $enumsService->enums;
+ *  </code>
+ */
+class Enums extends \Google\Service\Resource
+{
+  /**
+   * returns an object with enums (enums.get)
+   *
+   * @param array $optParams Optional parameters.
+   * @return ObjectWithEnums
+   */
+  public function get($optParams = [])
+  {
+    $params = [];
+    $params = array_merge($params, $optParams);
+    return $this->call('get', [$params], ObjectWithEnums::class);
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Enums::class, 'Google_Service_Enums_Resource_Enums');
+=== end: Enums/Resource/Enums.php

--- a/generator/tests/testdata/golden/php/default/enums.golden
+++ b/generator/tests/testdata/golden/php/default/enums.golden
@@ -178,6 +178,7 @@ class ObjectWithEnumProperty extends \Google\Model
   public $notEnum;
   /**
    * @var string
+   * @see Google\Service\Enums\Enums\ObjectWithEnumProperty\PropName
    */
   public $propName;
 

--- a/generator/tests/testdata/golden/php/default/kitchen_sink.golden
+++ b/generator/tests/testdata/golden/php/default/kitchen_sink.golden
@@ -767,6 +767,113 @@ class Enum extends \Google\Model
 // Adding a class alias for backwards compatibility with the previous class name.
 class_alias(Enum::class, 'Google_Service_KitchSink_Enum');
 === end: KitchSink/Enum.php
+=== begin: KitchSink/Enums/Alt.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\KitchSink\Enums;
+
+final class Alt
+{
+  /**
+   * The meaning for the enun value 'json'
+   * @var string
+   */
+  const JSON = "json";
+}
+=== end: KitchSink/Enums/Alt.php
+=== begin: KitchSink/Enums/LinkType.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\KitchSink\Enums;
+
+final class LinkType
+{
+  /**
+   * Doc comment for DOWNLOAD.
+   * @var string
+   */
+  const DOWNLOAD = "DOWNLOAD";
+  /**
+   * Doc comment for THUMBNAIL.
+   * @var string
+   */
+  const THUMBNAIL = "THUMBNAIL";
+  /**
+   * Doc comment for PDF.
+   * @var string
+   */
+  const PDF = "PDF";
+}
+=== end: KitchSink/Enums/LinkType.php
+=== begin: KitchSink/Enums/SeriesCounters/LinkType.php
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\KitchSink\Enums\SeriesCounters;
+
+final class LinkType
+{
+  /**
+   * Doc comment for DOWNLOAD.
+   * @var string
+   */
+  const DOWNLOAD = "DOWNLOAD";
+  /**
+   * Doc comment for THUMBNAIL.
+   * @var string
+   */
+  const THUMBNAIL = "THUMBNAIL";
+  /**
+   * Doc comment for PDF.
+   * @var string
+   */
+  const PDF = "PDF";
+}
+=== end: KitchSink/Enums/SeriesCounters/LinkType.php
 === begin: KitchSink/Geometry.php
 <?php
 /*

--- a/generator/tests/testdata/golden/php/default/kitchen_sink.golden
+++ b/generator/tests/testdata/golden/php/default/kitchen_sink.golden
@@ -2840,6 +2840,7 @@ class SeriesCounters extends \Google\Model
   public $submissions;
   /**
    * @var string
+   * @see Google\Service\KitchSink\Enums\SeriesCounters\LinkType
    */
   public $users;
 

--- a/generator/tests/testdata/golden_discovery/enums.json
+++ b/generator/tests/testdata/golden_discovery/enums.json
@@ -1,0 +1,82 @@
+{
+ "name": "enums",
+ "version": "v1",
+ "description": "verifying the PHP float primitive type",
+ "rootUrl": "https://www.googleapis.com/",
+ "servicePath" : "php_float_type/v1/",
+ "rpcPath": "/rpc",
+ "features": [
+  "dataWrapper"
+ ],
+ "parameters": {
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "A camelCased API parameter",
+   "default": "true",
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/userinfo.email": {
+     "description": "A typical scope"
+    },
+    "https://www.googleapis.com/auth/product": {
+     "description": "a product level scope"
+    },
+    "https://mail.google.com/": {
+      "description": "A non googleapis.com scope"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "SimpleEnum": {
+   "id": "SimpleEnum",
+   "type": "string",
+   "enum": [
+       "one",
+       "two"
+    ],
+    "enumDescriptions": [
+        "first",
+        "second"
+    ]
+  },
+  "ObjectWithEnumProperty": {
+    "type": "object",
+    "properties": {
+      "notEnum": {
+        "type": "string"
+      },
+      "propName": {
+        "type": "string",
+        "enum": [
+          "one",
+          "two"
+        ],
+        "enumDescriptions": [
+          "meaningful api docs here",
+          "and here too!"
+        ]
+      }
+    }
+  }
+ },
+ "resources": {
+  "enums": {
+   "methods": {
+    "get": {
+     "path": "enums",
+     "id": "enums.get",
+     "httpMethod": "GET",
+     "description": "returns an object with enums",
+     "response": {
+      "$ref": "ObjectWithEnums"
+     }
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
I had some stuff [in another PR](https://github.com/google/apis-client-generator/pull/44/commits/2fa5944591791923284b44b10e70a1137d33b383) around enums, but wasn't super happy with it.

This adds an `Enums` namespace to the generated package and an enum class that's just a bag of constants. Properties that have enum values have an `@see` thing in the docblock pointing to the class.

One thing that's not great here is that schema references for enums create classes, you can see this in the kitchen sink tests where there's a top level `LinkType` enum: https://github.com/chrisguitarguy/google-api-php-client-services/blob/6f32078f280c4278d8951fadaec618ac9ea67b3f/generator/tests/testdata/golden/php/default/kitchen_sink.golden#L819

 and a `LinkType` enum under `SeriesCounters`: https://github.com/chrisguitarguy/google-api-php-client-services/blob/6f32078f280c4278d8951fadaec618ac9ea67b3f/generator/tests/testdata/golden/php/default/kitchen_sink.golden#L858

There's not really a way to determine if the schema is actually a reference or not in the generator code and I didn't want to dig too far into that before asking for feedback. If a schema has already been defined, the reference is just resolved directly: https://github.com/chrisguitarguy/google-api-php-client-services/blob/6f32078f280c4278d8951fadaec618ac9ea67b3f/generator/src/googleapis/codegen/schema.py#L200-L207