### PR TITLE
chore: add macos to matrix for case-insensitive checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,14 @@ on:
 
 jobs:
     test:
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         strategy:
             matrix:
+                os: [ubuntu-latest]
                 php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0" ]
+                include:
+                  - os: macos-latest
+                    php: "8.0"
         name: PHP ${{matrix.php }} Unit Test
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Issue #606 happened because we are not running tests on a case-insensitive filesystem. Adding `macos-latest` to our tests so this can't happen again.