### PR TITLE
fix: incomplete list of return values

### DIFF
--- a/src/AndroidPublisher/ProductPurchase.php
+++ b/src/AndroidPublisher/ProductPurchase.php
@@ -238,7 +238,7 @@ class ProductPurchase extends \Google\Model
     $this->purchaseType = $purchaseType;
   }
   /**
-   * @return int
+   * @return int|null
    */
   public function getPurchaseType()
   {


### PR DESCRIPTION
According to the Google Play Developer API documentation (https://developers.google.com/android-publisher/api-ref/rest/v3/purchases.products), the PurchaseType field is only set if that purchase was not made using the standard in-app billing process. In most cases, this field will be NULL , however, the type hint of the method that returns this value is only int.

I fell into this trap. This is very confusing, you can ignore that the purchaseType field can be NULL (in most cases this field will be NULL)