### PR TITLE
Fix bug in ProductsCustomBatchRequestEntry. When submitting bulk prod…

### DIFF
--- a/src/ShoppingContent/ProductsCustomBatchRequestEntry.php
+++ b/src/ShoppingContent/ProductsCustomBatchRequestEntry.php
@@ -19,6 +19,7 @@ namespace Google\Service\ShoppingContent;
 
 class ProductsCustomBatchRequestEntry extends \Google\Model
 {
+  /* Note public properties are needed because library uses Reflection to flatten this class into JSON for API */
   /**
    * @var string
    */
@@ -41,6 +42,10 @@ class ProductsCustomBatchRequestEntry extends \Google\Model
    * @var string
    */
   public $productId;
+  /**
+   * @var Product
+   */
+  public $product;
   /**
    * @var string
    */


### PR DESCRIPTION
Fix bug in ProductsCustomBatchRequestEntry. When submitting bulk product updates, this class is reflected and turned into JSON for the POST body in the update payload.

Because there was no public 'product' property in this class, when the class was reflected, this was not added to the JSON in the post body, resulting in this error from the API:

Error [product] INSERT request must specify product

@see https://stackoverflow.com/questions/69617207/google-api-2-1-error-product-insert-request-must-specify-product

(... there are other examples of this error manifesting, even from other libraries, this error is not exclusive to this particular bug)