### PR TITLE
FIX - add required parameter for batchUpdate

### DIFF
--- a/src/Sheets.php
+++ b/src/Sheets.php
@@ -291,6 +291,10 @@ class Sheets extends \Google\Service
                   'type' => 'string',
                   'required' => true,
                 ],
+                'valueInputOption' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
               ],
             ],'batchUpdateByDataFilter' => [
               'path' => 'v4/spreadsheets/{spreadsheetId}/values:batchUpdateByDataFilter',


### PR DESCRIPTION
It's not possible to use the batchUpdate operation without this param:
```
Fatal error: Uncaught Google\Service\Exception: {
  "error": {
    "code": 400,
    "message": "'valueInputOption' is required but not specified",
    "errors": [
      {
        "message": "'valueInputOption' is required but not specified",
        "domain": "global",
        "reason": "badRequest"
      }
    ],
    "status": "INVALID_ARGUMENT"
  }
}
```

But adding it will also cause an issue because it's not defined:

```
Google\Exception: (batchUpdate) unknown parameter: 'valueInputOption'
```