### PR TITLE
Fix: Declare `$start` and `$end` properties explicitly

### DIFF
--- a/src/Calendar/Event.php
+++ b/src/Calendar/Event.php
@@ -280,7 +280,7 @@ class Event extends \Google\Collection
     return $this->description;
   }
   /**
-   * @param EventDateTime
+   * @param EventDateTime $end
    */
   public function setEnd(EventDateTime $end)
   {
@@ -616,7 +616,7 @@ class Event extends \Google\Collection
     return $this->source;
   }
   /**
-   * @param EventDateTime
+   * @param EventDateTime $start
    */
   public function setStart(EventDateTime $start)
   {

--- a/src/Calendar/Event.php
+++ b/src/Calendar/Event.php
@@ -130,6 +130,10 @@ class Event extends \Google\Collection
   public $sequence;
   protected $sourceType = EventSource::class;
   protected $sourceDataType = '';
+  /**
+   * @var EventDateTime|null
+   */
+  protected $start = null;
   protected $startType = EventDateTime::class;
   protected $startDataType = '';
   /**
@@ -623,7 +627,7 @@ class Event extends \Google\Collection
     $this->start = $start;
   }
   /**
-   * @return EventDateTime
+   * @return EventDateTime|null
    */
   public function getStart()
   {

--- a/src/Calendar/Event.php
+++ b/src/Calendar/Event.php
@@ -48,6 +48,10 @@ class Event extends \Google\Collection
    * @var string
    */
   public $description;
+  /**
+   * @var EventDateTime|null
+   */
+  protected $end = null;
   protected $endType = EventDateTime::class;
   protected $endDataType = '';
   /**
@@ -291,7 +295,7 @@ class Event extends \Google\Collection
     $this->end = $end;
   }
   /**
-   * @return EventDateTime
+   * @return EventDateTime|null
    */
   public function getEnd()
   {


### PR DESCRIPTION
This PR;
- declares `$start` and `$end` properties explicitly (since they're currently dynamic properties and [`getStart`](https://github.com/googleapis/google-api-php-client-services/blob/main/src/Calendar/Event.php#L628) & [`getEnd`](https://github.com/googleapis/google-api-php-client-services/blob/main/src/Calendar/Event.php#L292) methods return `null` when `$start` and `$end` has not been set yet),
- corrects a couple of invalid PHPDoc annotations.

PS: Dynamic properties will be deprecated as of PHP 8.2 ([wiki](https://wiki.php.net/rfc/deprecate_dynamic_properties)).