### PR TITLE
Adding another parameter to insert method.

### DIFF
--- a/src/YouTube/Resource/Videos.php
+++ b/src/YouTube/Resource/Videos.php
@@ -126,10 +126,10 @@ class Videos extends \Google\Service\Resource
    * @opt_param bool stabilize Should stabilize be applied to the upload.
    * @return Video
    */
-  public function insert($part, Video $postBody, $optParams = [])
+  public function insert($part, Video $postBody, $optParams = [], $otherParams = [])
   {
     $params = ['part' => $part, 'postBody' => $postBody];
-    $params = array_merge($params, $optParams);
+    $params = array_merge($params, $optParams, $otherParams);
     return $this->call('insert', [$params], Video::class);
   }
   /**


### PR DESCRIPTION
Adding another parameter to insert method. 

I have tried to upload a video to one of the channels that are linked with our CMS. The current code does not accept the fourth parameter, it returned `Request contains an invalid argument.`.

Here what I tried:
```php
$queryParams = [
    'onBehalfOfContentOwner' => 'CONTENT_OWNER_ID',
    'onBehalfOfContentOwnerChannel' => 'CHANNEL_ID_THAT_BELONGSTO_CONTENT_OWNER', 
];

$response = $service->videos->insert(
    'snippet,status',
    $video,
    $queryParams,
    [
        'data' => file_get_contents("YOUR_FILE_PATH"),
        'mimeType' => 'application/octet-stream',
        'uploadType' => 'multipart',
    ]
);
```