### PR TITLE
fix: revert errant changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04]
-                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0", 8.1, 8.2 ]
+                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0", 8.1 ]
                 include:
                   - os: macos-latest
                     php: "8.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04]
-                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0", 8.1 ]
+                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0", 8.1, 8.2 ]
                 include:
                   - os: macos-latest
                     php: "8.0"

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
@@ -32,7 +32,7 @@ class {{ model.className }} extends {% if model.superClass %}{{ model.superClass
    */
  {% endif %}
  {% endif %}
-  public ${{ property.memberName }}{% if property.dataType == "array" or property.dataType == "map" %} = []{% endif %};
+  public ${{ property.memberName }};
 {% endfor %}
 {% endfilter %}
 {% filter noblanklines %}

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___/___models_className___.php.tmpl
@@ -31,8 +31,8 @@ class {{ model.className }} extends {% if model.superClass %}{{ model.superClass
    * @var {{ property.annotationType }}{% if property.dataType == "array" or property.dataType == "map" %}[]{% endif %}
    */
  {% endif %}
- {% endif %}
   public ${{ property.memberName }};
+ {% endif %}
 {% endfor %}
 {% endfilter %}
 {% filter noblanklines %}

--- a/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
@@ -172,7 +172,7 @@ class HelloGreetingCollection extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = HelloGreeting::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
 
   /**
    * @param HelloGreeting[]

--- a/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
@@ -172,7 +172,6 @@ class HelloGreetingCollection extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = HelloGreeting::class;
   protected $itemsDataType = 'array';
-  public $items;
 
   /**
    * @param HelloGreeting[]

--- a/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
@@ -172,7 +172,7 @@ class HelloGreetingCollection extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = HelloGreeting::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
 
   /**
    * @param HelloGreeting[]

--- a/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
@@ -172,7 +172,6 @@ class HelloGreetingCollection extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = HelloGreeting::class;
   protected $itemsDataType = 'array';
-  public $items;
 
   /**
    * @param HelloGreeting[]

--- a/generator/tests/testdata/golden/php/default/kitchen_sink.golden
+++ b/generator/tests/testdata/golden/php/default/kitchen_sink.golden
@@ -840,7 +840,6 @@ class GeometryCollection extends Geometry
   protected $collection_key = 'geometries';
   protected $geometriesType = Geometry::class;
   protected $geometriesDataType = 'array';
-  public $geometries;
   protected function gapiInit()
   {
     $this->type = 'Collection';
@@ -1127,10 +1126,8 @@ class Profile extends \Google\Model
 {
   protected $attributionType = ProfileAttribution::class;
   protected $attributionDataType = '';
-  public $attribution;
   protected $idType = ProfileId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -1215,7 +1212,6 @@ class ProfileAttribution extends \Google\Model
   public $displayName;
   protected $geoType = LatLong::class;
   protected $geoDataType = '';
-  public $geo;
   /**
    * @var string
    */
@@ -2476,7 +2472,6 @@ class Rule extends \Google\Model
 {
   protected $submissionsType = RuleSubmissions::class;
   protected $submissionsDataType = '';
-  public $submissions;
 
   /**
    * @param RuleSubmissions
@@ -2589,14 +2584,12 @@ class Series extends \Google\Model
   public $anonymousSubmissionAllowed;
   protected $countersType = SeriesCounters::class;
   protected $countersDataType = '';
-  public $counters;
   /**
    * @var string
    */
   public $description;
   protected $idType = SeriesId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -2764,7 +2757,6 @@ class SeriesCounters extends \Google\Model
   public $anonymousSubmissions;
   protected $countersType = SeriesCountersCounters::class;
   protected $countersDataType = '';
-  public $counters;
   /**
    * @var int
    */
@@ -3027,7 +3019,6 @@ class SeriesList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Series::class;
   protected $itemsDataType = 'array';
-  public $items;
   /**
    * @var string
    */
@@ -3098,41 +3089,34 @@ class Submission extends \Google\Collection
   public $attachmentUrl;
   protected $attributionType = SubmissionAttribution::class;
   protected $attributionDataType = '';
-  public $attribution;
   /**
    * @var string
    */
   public $author;
   protected $countersType = SubmissionCounters::class;
   protected $countersDataType = '';
-  public $counters;
   /**
    * @var int
    */
   public $created;
   protected $geoType = LatLong::class;
   protected $geoDataType = 'array';
-  public $geo;
   protected $idType = SubmissionId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
   public $kind;
   protected $parentSubmissionIdType = SubmissionParentSubmissionId::class;
   protected $parentSubmissionIdDataType = '';
-  public $parentSubmissionId;
   /**
    * @var string
    */
   public $text;
   protected $topicsType = ModeratorTopicsResourcePartial::class;
   protected $topicsDataType = 'array';
-  public $topics;
   protected $translationsType = Translation::class;
   protected $translationsDataType = 'map';
-  public $translations;
 
   /**
    * @param string
@@ -3569,7 +3553,6 @@ class SubmissionList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Submission::class;
   protected $itemsDataType = 'array';
-  public $items;
   /**
    * @var string
    */
@@ -3696,10 +3679,8 @@ class Tag extends \Google\Model
 {
   protected $geometryType = Geometry::class;
   protected $geometryDataType = '';
-  public $geometry;
   protected $idType = TagId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -3876,14 +3857,12 @@ class Topic extends \Google\Model
 {
   protected $countersType = TopicCounters::class;
   protected $countersDataType = '';
-  public $counters;
   /**
    * @var string
    */
   public $description;
   protected $idType = TopicId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -3898,7 +3877,6 @@ class Topic extends \Google\Model
   public $presenter;
   protected $rulesType = TopicRules::class;
   protected $rulesDataType = '';
-  public $rules;
 
   /**
    * @param TopicCounters
@@ -4028,17 +4006,14 @@ class Topic2 extends \Google\Collection
   protected $collection_key = 'rules';
   protected $countersType = Topic2Counters::class;
   protected $countersDataType = '';
-  public $counters;
   /**
    * @var string
    */
   public $description;
   protected $featuredSubmissionType = Submission::class;
   protected $featuredSubmissionDataType = '';
-  public $featuredSubmission;
   protected $idType = Topic2Id::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -4053,7 +4028,6 @@ class Topic2 extends \Google\Collection
   public $presenter;
   protected $rulesType = Rule::class;
   protected $rulesDataType = 'array';
-  public $rules;
 
   /**
    * @param Topic2Counters
@@ -4607,7 +4581,6 @@ class TopicList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Topic::class;
   protected $itemsDataType = 'array';
-  public $items;
   /**
    * @var string
    */
@@ -4670,10 +4643,8 @@ class TopicRules extends \Google\Model
 {
   protected $submissionsType = TopicRulesSubmissions::class;
   protected $submissionsDataType = '';
-  public $submissions;
   protected $votesType = TopicRulesVotes::class;
   protected $votesDataType = '';
-  public $votes;
 
   /**
    * @param TopicRulesSubmissions
@@ -4928,7 +4899,6 @@ class Vote extends \Google\Model
   public $flag;
   protected $idType = VoteId::class;
   protected $idDataType = '';
-  public $id;
   /**
    * @var string
    */
@@ -5051,7 +5021,6 @@ class VoteList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Vote::class;
   protected $itemsDataType = 'array';
-  public $items;
   /**
    * @var string
    */

--- a/generator/tests/testdata/golden/php/default/kitchen_sink.golden
+++ b/generator/tests/testdata/golden/php/default/kitchen_sink.golden
@@ -840,7 +840,7 @@ class GeometryCollection extends Geometry
   protected $collection_key = 'geometries';
   protected $geometriesType = Geometry::class;
   protected $geometriesDataType = 'array';
-  public $geometries = [];
+  public $geometries;
   protected function gapiInit()
   {
     $this->type = 'Collection';
@@ -3027,7 +3027,7 @@ class SeriesList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Series::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
   /**
    * @var string
    */
@@ -3112,7 +3112,7 @@ class Submission extends \Google\Collection
   public $created;
   protected $geoType = LatLong::class;
   protected $geoDataType = 'array';
-  public $geo = [];
+  public $geo;
   protected $idType = SubmissionId::class;
   protected $idDataType = '';
   public $id;
@@ -3129,10 +3129,10 @@ class Submission extends \Google\Collection
   public $text;
   protected $topicsType = ModeratorTopicsResourcePartial::class;
   protected $topicsDataType = 'array';
-  public $topics = [];
+  public $topics;
   protected $translationsType = Translation::class;
   protected $translationsDataType = 'map';
-  public $translations = [];
+  public $translations;
 
   /**
    * @param string
@@ -3569,7 +3569,7 @@ class SubmissionList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Submission::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
   /**
    * @var string
    */
@@ -4053,7 +4053,7 @@ class Topic2 extends \Google\Collection
   public $presenter;
   protected $rulesType = Rule::class;
   protected $rulesDataType = 'array';
-  public $rules = [];
+  public $rules;
 
   /**
    * @param Topic2Counters
@@ -4607,7 +4607,7 @@ class TopicList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Topic::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
   /**
    * @var string
    */
@@ -5051,7 +5051,7 @@ class VoteList extends \Google\Collection
   protected $collection_key = 'items';
   protected $itemsType = Vote::class;
   protected $itemsDataType = 'array';
-  public $items = [];
+  public $items;
   /**
    * @var string
    */

--- a/generator/tests/testdata/golden/php/default/php_array_scalars.golden
+++ b/generator/tests/testdata/golden/php/default/php_array_scalars.golden
@@ -108,19 +108,19 @@ class ObjectWithScalarArrays extends \Google\Collection
   /**
    * @var bool[]
    */
-  public $arrayOfBooleans = [];
+  public $arrayOfBooleans;
   /**
    * @var float[]
    */
-  public $arrayOfFloats = [];
+  public $arrayOfFloats;
   /**
    * @var int[]
    */
-  public $arrayOfIntegers = [];
+  public $arrayOfIntegers;
   /**
    * @var string[]
    */
-  public $arrayOfStrings = [];
+  public $arrayOfStrings;
 
   /**
    * @param bool[]


### PR DESCRIPTION
adding the dynamic properties to classes in #2258 and #1836 seem to have broken everything due to the use of `__set` in the parent `Google\Model` class. Rather than add the properties, just mark the class as having dynamic properties, and revert all these changes: https://github.com/googleapis/google-api-php-client/pull/2408

Fixes https://github.com/googleapis/google-api-php-client-services/issues/2350