### PR TITLE
fix: Upgrade tests version to tests php >= 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04]
-                php: [ 5.6, "7.0", 7.1, 7.2, 7.3, 7.4, "8.0", 8.1, 8.2 ]
+                php: [ 7.4, "8.0", 8.1, 8.2 ]
                 include:
                   - os: macos-latest
                     php: "8.0"


### PR DESCRIPTION
This PR is supposed to fix all the failing autogenerated PRs in this repo due to us still testing for php version 5.6 to 7.3 whereas we have dropped the support for them.