### PR TITLE
Fix nullability of EventDateTime::$date & $dateTime

### DIFF
--- a/src/Calendar/EventDateTime.php
+++ b/src/Calendar/EventDateTime.php
@@ -20,11 +20,11 @@ namespace Google\Service\Calendar;
 class EventDateTime extends \Google\Model
 {
   /**
-   * @var string
+   * @var string|null
    */
   public $date;
   /**
-   * @var string
+   * @var string|null
    */
   public $dateTime;
   /**
@@ -33,28 +33,28 @@ class EventDateTime extends \Google\Model
   public $timeZone;
 
   /**
-   * @param string
+   * @param string|null
    */
   public function setDate($date)
   {
     $this->date = $date;
   }
   /**
-   * @return string
+   * @return string|null
    */
   public function getDate()
   {
     return $this->date;
   }
   /**
-   * @param string
+   * @param string|null
    */
   public function setDateTime($dateTime)
   {
     $this->dateTime = $dateTime;
   }
   /**
-   * @return string
+   * @return string|null
    */
   public function getDateTime()
   {


### PR DESCRIPTION
It looks like one of `$date` or `$dateTime` is set at a given time, and the other is null.