### PR TITLE
Modify autoload for hitting disc and checking is file existing

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,50 +1,40 @@
 <?php
 
-if (
-    class_exists('Google\\Client')
-    || (
-        class_exists('Composer\\InstalledVersions')
-        && version_compare(\Composer\InstalledVersions::getVersion('google/apiclient'), '2.7.2', '>')
-    )
-) {
-    return;
-} elseif (
-    // For older (pre-2.7.2) verions of google/apiclient
-    file_exists(__DIR__ . '/../apiclient/src/Google/Client.php')
-    && !class_exists('Google_Client', false)
-) {
-    load_legacy_namespace();
-}
+// Autoloader function for classes starting with 'Google_Service_'
+spl_autoload_register(function ($class) {
+    if (0 === strpos($class, 'Google_Service_')) {
+        // Autoload the new class, which will also create an alias for the
+        // old class by changing underscores to namespaces:
+        //     Google_Service_Speech_Resource_Operations
+        //      => Google\Service\Speech\Resource\Operations
+        $classExists = class_exists($newClass = str_replace('_', '\\', $class));
 
-function load_legacy_namespace()
-{
-    require_once(__DIR__ . '/../apiclient/src/Google/Client.php');
-    if (
-        defined('Google_Client::LIBVER')
-        && version_compare(Google_Client::LIBVER, '2.7.2', '<=')
-    ) {
-        $servicesClassMap = [
-            'Google\\Client' => 'Google_Client',
-            'Google\\Service' => 'Google_Service',
-            'Google\\Service\\Resource' => 'Google_Service_Resource',
-            'Google\\Model' => 'Google_Model',
-            'Google\\Collection' => 'Google_Collection',
-        ];
-        foreach ($servicesClassMap as $alias => $class) {
-            class_alias($class, $alias);
-        }
-    }
+        if (!$classExists && !class_exists('Google_Client', false)) {
+            $clientPath = __DIR__ . '/../apiclient/src/Google/Client.php';
 
-    spl_autoload_register(function ($class) {
-        if (0 === strpos($class, 'Google_Service_')) {
-            // Autoload the new class, which will also create an alias for the
-            // old class by changing underscores to namespaces:
-            //     Google_Service_Speech_Resource_Operations
-            //      => Google\Service\Speech\Resource\Operations
-            $classExists = class_exists($newClass = str_replace('_', '\\', $class));
-            if ($classExists) {
-                return true;
+            // For older (pre-2.7.2) versions of google/apiclient
+            if (file_exists($clientPath)) {
+                require_once($clientPath);
+
+                if (
+                    defined('Google_Client::LIBVER')
+                    && version_compare(Google_Client::LIBVER, '2.7.2', '<=')
+                ) {
+                    $servicesClassMap = [
+                        'Google\\Client' => 'Google_Client',
+                        'Google\\Service' => 'Google_Service',
+                        'Google\\Service\\Resource' => 'Google_Service_Resource',
+                        'Google\\Model' => 'Google_Model',
+                        'Google\\Collection' => 'Google_Collection',
+                    ];
+
+                    foreach ($servicesClassMap as $alias => $newClass) {
+                        class_alias($newClass, $alias);
+                    }
+                }
             }
         }
-    }, true, true);
-}
+
+        return $classExists;
+    }
+}, true, true);


### PR DESCRIPTION
The autoload was originally introduced in Pull Request #363 for supporting legacy classes. 

Main idea is to avoid hitting disc which is done with calling `file_exists(__DIR__ . '/../apiclient/src/Google/Client.php')` and looking for a file, which in case that a newer version of `google/apiclient` than `2.7.2` results with failing check, specifically it looks for file `vendor/google/apiclient-services/../apiclient/src/Google/Client.php` and that results with no such file or directory.