### PR TITLE
feat: add support for universe domain

### DIFF
--- a/generator/src/googleapis/codegen/api.py
+++ b/generator/src/googleapis/codegen/api.py
@@ -331,8 +331,11 @@ class Api(template_objects.CodeObject):
     scheme = url_parts.scheme or 'https'
     service_host = url_parts.netloc or _DEFAULT_SERVICE_HOST
     base_path = url_parts.path
-    if not root_url:
+    if root_url:
+      self._api.SetTemplateValue('rootUrlTemplate', root_url.replace('googleapis.com', 'UNIVERSE_DOMAIN'))
+    else:
       self._api.SetTemplateValue('rootUrl', '%s://%s/' % (scheme, service_host))
+      self._api.SetTemplateValue('rootUrlTemplate', '%s://%s/' % (scheme, service_host.replace('googleapis.com', 'UNIVERSE_DOMAIN')))
     if service_path is None:
       self._api.SetTemplateValue('servicePath', base_path[1:])
 

--- a/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___.php.tmpl
+++ b/generator/src/googleapis/codegen/languages/php/default/templates/___api_className___.php.tmpl
@@ -30,6 +30,7 @@ const {{ authscope.name }} =
 {% endfor %}{% endindent %}{% endfilter %}{% endif %}
 
 {% call_template _resource_var resource=api %}
+  public $rootUrlTemplate;
 {% if api.methods %}  private $base_methods;{% endif %}
   /**{% filter block_comment %}
    * Constructs the internal representation of the {{ api.className }} service.
@@ -45,6 +46,7 @@ const {{ authscope.name }} =
 {% indent 2 %}
 parent::__construct($clientOrConfig);
 $this->rootUrl = $rootUrl ?: {% literal api.rootUrl %};
+$this->rootUrlTemplate = $rootUrl ?: {% literal api.rootUrlTemplate %};
 $this->servicePath = {% literal api.servicePath %};
 {% if api.batchPath %}$this->batchPath = {% literal api.batchPath %};{% endif %}
 $this->version = {% literal api.version %};

--- a/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_google_owned.golden
@@ -40,6 +40,7 @@ class EccoDomaniIeri extends \Google\Service
       "https://www.googleapis.com/auth/userinfo.email";
 
   public $greetings;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the EccoDomaniIeri service.
@@ -52,6 +53,7 @@ class EccoDomaniIeri extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://peer-pontus.appspot.com/_ah/api/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://peer-pontus.appspot.com/_ah/api/';
     $this->servicePath = 'helloworld/v1/';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
+++ b/generator/tests/testdata/golden/php/default/endpoints_third_party.golden
@@ -40,6 +40,7 @@ class EccoDomaniIeri extends \Google\Service
       "https://www.googleapis.com/auth/userinfo.email";
 
   public $greetings;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the EccoDomaniIeri service.
@@ -52,6 +53,7 @@ class EccoDomaniIeri extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://peer-pontus.appspot.com/_ah/api/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://peer-pontus.appspot.com/_ah/api/';
     $this->servicePath = 'helloworld/v1/';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/generator/tests/testdata/golden/php/default/kitchen_sink.golden
+++ b/generator/tests/testdata/golden/php/default/kitchen_sink.golden
@@ -60,6 +60,7 @@ class KitchSink extends \Google\Service
   public $topics;
   public $topics_submissions;
   public $votes;
+  public $rootUrlTemplate;
   private $base_methods;
   /**
    * Constructs the internal representation of the KitchSink service.
@@ -72,6 +73,7 @@ class KitchSink extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'sink/v1/';
     $this->version = 'v1';
     $this->serviceName = 'kitch_sink';

--- a/generator/tests/testdata/golden/php/default/php_array_scalars.golden
+++ b/generator/tests/testdata/golden/php/default/php_array_scalars.golden
@@ -46,6 +46,7 @@ class PhpArrayScalars extends \Google\Service
       "https://www.googleapis.com/auth/userinfo.email";
 
   public $getwitharrays;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PhpArrayScalars service.
@@ -58,6 +59,7 @@ class PhpArrayScalars extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'php_float_type/v1/';
     $this->version = 'v1';
     $this->serviceName = 'php_array_scalars';

--- a/generator/tests/testdata/golden/php/default/php_float_type.golden
+++ b/generator/tests/testdata/golden/php/default/php_float_type.golden
@@ -46,6 +46,7 @@ class PhpFloatType extends \Google\Service
       "https://www.googleapis.com/auth/userinfo.email";
 
   public $getwithfloat;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PhpFloatType service.
@@ -58,6 +59,7 @@ class PhpFloatType extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'php_float_type/v1/';
     $this->version = 'v1';
     $this->serviceName = 'php_float_type';

--- a/src/AIPlatformNotebooks.php
+++ b/src/AIPlatformNotebooks.php
@@ -41,6 +41,7 @@ class AIPlatformNotebooks extends \Google\Service
   public $projects_locations;
   public $projects_locations_instances;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AIPlatformNotebooks service.
@@ -53,6 +54,7 @@ class AIPlatformNotebooks extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://notebooks.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://notebooks.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/AbusiveExperienceReport.php
+++ b/src/AbusiveExperienceReport.php
@@ -39,6 +39,7 @@ class AbusiveExperienceReport extends \Google\Service
 
   public $sites;
   public $violatingSites;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AbusiveExperienceReport
@@ -52,6 +53,7 @@ class AbusiveExperienceReport extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://abusiveexperiencereport.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://abusiveexperiencereport.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Acceleratedmobilepageurl.php
+++ b/src/Acceleratedmobilepageurl.php
@@ -38,6 +38,7 @@ class Acceleratedmobilepageurl extends \Google\Service
 
 
   public $ampUrls;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Acceleratedmobilepageurl
@@ -51,6 +52,7 @@ class Acceleratedmobilepageurl extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://acceleratedmobilepageurl.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://acceleratedmobilepageurl.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AccessApproval.php
+++ b/src/AccessApproval.php
@@ -44,6 +44,7 @@ class AccessApproval extends \Google\Service
   public $organizations_approvalRequests;
   public $projects;
   public $projects_approvalRequests;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AccessApproval service.
@@ -56,6 +57,7 @@ class AccessApproval extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://accessapproval.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://accessapproval.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AccessContextManager.php
+++ b/src/AccessContextManager.php
@@ -54,6 +54,7 @@ class AccessContextManager extends \Google\Service
   public $operations;
   public $organizations_gcpUserAccessBindings;
   public $services;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AccessContextManager service.
@@ -66,6 +67,7 @@ class AccessContextManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://accesscontextmanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://accesscontextmanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AdExchangeBuyerII.php
+++ b/src/AdExchangeBuyerII.php
@@ -82,6 +82,7 @@ class AdExchangeBuyerII extends \Google\Service
   public $buyers_filterSets_impressionMetrics;
   public $buyers_filterSets_losingBids;
   public $buyers_filterSets_nonBillableWinningBids;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AdExchangeBuyerII service.
@@ -94,6 +95,7 @@ class AdExchangeBuyerII extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://adexchangebuyer.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://adexchangebuyer.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2beta1';

--- a/src/AdExperienceReport.php
+++ b/src/AdExperienceReport.php
@@ -39,6 +39,7 @@ class AdExperienceReport extends \Google\Service
 
   public $sites;
   public $violatingSites;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AdExperienceReport service.
@@ -51,6 +52,7 @@ class AdExperienceReport extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://adexperiencereport.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://adexperiencereport.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AdMob.php
+++ b/src/AdMob.php
@@ -47,6 +47,7 @@ class AdMob extends \Google\Service
   public $accounts_apps;
   public $accounts_mediationReport;
   public $accounts_networkReport;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AdMob service.
@@ -59,6 +60,7 @@ class AdMob extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://admob.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://admob.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AdSenseHost.php
+++ b/src/AdSenseHost.php
@@ -48,6 +48,7 @@ class AdSenseHost extends \Google\Service
   public $customchannels;
   public $reports;
   public $urlchannels;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AdSenseHost service.
@@ -60,6 +61,7 @@ class AdSenseHost extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'adsensehost/v4.1/';
     $this->batchPath = 'batch/adsensehost/v4.1';
     $this->version = 'v4.1';

--- a/src/Adsense.php
+++ b/src/Adsense.php
@@ -53,6 +53,7 @@ class Adsense extends \Google\Service
   public $accounts_reports;
   public $accounts_reports_saved;
   public $accounts_sites;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Adsense service.
@@ -65,6 +66,7 @@ class Adsense extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://adsense.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://adsense.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/AlertCenter.php
+++ b/src/AlertCenter.php
@@ -42,6 +42,7 @@ class AlertCenter extends \Google\Service
   public $alerts;
   public $alerts_feedback;
   public $v1beta1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AlertCenter service.
@@ -54,6 +55,7 @@ class AlertCenter extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://alertcenter.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://alertcenter.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -82,6 +82,7 @@ class Analytics extends \Google\Service
   public $metadata_columns;
   public $provisioning;
   public $userDeletion_userDeletionRequest;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Analytics service.
@@ -94,6 +95,7 @@ class Analytics extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://analytics.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://analytics.UNIVERSE_DOMAIN/';
     $this->servicePath = 'analytics/v3/';
     $this->batchPath = 'batch/analytics/v3';
     $this->version = 'v3';

--- a/src/AnalyticsData.php
+++ b/src/AnalyticsData.php
@@ -49,6 +49,7 @@ class AnalyticsData extends \Google\Service
 
   public $properties;
   public $properties_audienceExports;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AnalyticsData service.
@@ -61,6 +62,7 @@ class AnalyticsData extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://analyticsdata.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://analyticsdata.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta';

--- a/src/AnalyticsHub.php
+++ b/src/AnalyticsHub.php
@@ -45,6 +45,7 @@ class AnalyticsHub extends \Google\Service
   public $projects_locations_dataExchanges;
   public $projects_locations_dataExchanges_listings;
   public $projects_locations_subscriptions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AnalyticsHub service.
@@ -57,6 +58,7 @@ class AnalyticsHub extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://analyticshub.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://analyticshub.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AnalyticsReporting.php
+++ b/src/AnalyticsReporting.php
@@ -43,6 +43,7 @@ class AnalyticsReporting extends \Google\Service
 
   public $reports;
   public $userActivity;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AnalyticsReporting service.
@@ -55,6 +56,7 @@ class AnalyticsReporting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://analyticsreporting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://analyticsreporting.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v4';

--- a/src/AndroidEnterprise.php
+++ b/src/AndroidEnterprise.php
@@ -54,6 +54,7 @@ class AndroidEnterprise extends \Google\Service
   public $storelayoutpages;
   public $users;
   public $webapps;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AndroidEnterprise service.
@@ -66,6 +67,7 @@ class AndroidEnterprise extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://androidenterprise.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://androidenterprise.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AndroidManagement.php
+++ b/src/AndroidManagement.php
@@ -50,6 +50,7 @@ class AndroidManagement extends \Google\Service
   public $enterprises_webTokens;
   public $provisioningInfo;
   public $signupUrls;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AndroidManagement service.
@@ -62,6 +63,7 @@ class AndroidManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://androidmanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://androidmanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AndroidProvisioningPartner.php
+++ b/src/AndroidProvisioningPartner.php
@@ -46,6 +46,7 @@ class AndroidProvisioningPartner extends \Google\Service
   public $partners_devices;
   public $partners_vendors;
   public $partners_vendors_customers;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AndroidProvisioningPartner
@@ -59,6 +60,7 @@ class AndroidProvisioningPartner extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://androiddeviceprovisioning.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://androiddeviceprovisioning.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AndroidPublisher.php
+++ b/src/AndroidPublisher.php
@@ -71,6 +71,7 @@ class AndroidPublisher extends \Google\Service
   public $reviews;
   public $systemapks_variants;
   public $users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AndroidPublisher service.
@@ -83,6 +84,7 @@ class AndroidPublisher extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://androidpublisher.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://androidpublisher.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/ApiKeysService.php
+++ b/src/ApiKeysService.php
@@ -44,6 +44,7 @@ class ApiKeysService extends \Google\Service
   public $keys;
   public $operations;
   public $projects_locations_keys;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ApiKeysService service.
@@ -56,6 +57,7 @@ class ApiKeysService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://apikeys.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://apikeys.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Apigateway.php
+++ b/src/Apigateway.php
@@ -43,6 +43,7 @@ class Apigateway extends \Google\Service
   public $projects_locations_apis_configs;
   public $projects_locations_gateways;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Apigateway service.
@@ -55,6 +56,7 @@ class Apigateway extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://apigateway.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://apigateway.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Apigee.php
+++ b/src/Apigee.php
@@ -125,6 +125,7 @@ class Apigee extends \Google\Service
   public $organizations_sites_apicategories;
   public $organizations_sites_apidocs;
   public $projects;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Apigee service.
@@ -137,6 +138,7 @@ class Apigee extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://apigee.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://apigee.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ApigeeRegistry.php
+++ b/src/ApigeeRegistry.php
@@ -52,6 +52,7 @@ class ApigeeRegistry extends \Google\Service
   public $projects_locations_instances;
   public $projects_locations_operations;
   public $projects_locations_runtime;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ApigeeRegistry service.
@@ -64,6 +65,7 @@ class ApigeeRegistry extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://apigeeregistry.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://apigeeregistry.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Appengine.php
+++ b/src/Appengine.php
@@ -55,6 +55,7 @@ class Appengine extends \Google\Service
   public $apps_services_versions;
   public $apps_services_versions_instances;
   public $projects_locations_applications_authorizedDomains;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Appengine service.
@@ -67,6 +68,7 @@ class Appengine extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://appengine.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://appengine.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Area120Tables.php
+++ b/src/Area120Tables.php
@@ -56,6 +56,7 @@ class Area120Tables extends \Google\Service
   public $tables;
   public $tables_rows;
   public $workspaces;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Area120Tables service.
@@ -68,6 +69,7 @@ class Area120Tables extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://area120tables.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://area120tables.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1alpha1';

--- a/src/ArtifactRegistry.php
+++ b/src/ArtifactRegistry.php
@@ -60,6 +60,7 @@ class ArtifactRegistry extends \Google\Service
   public $projects_locations_repositories_packages_versions;
   public $projects_locations_repositories_pythonPackages;
   public $projects_locations_repositories_yumArtifacts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ArtifactRegistry service.
@@ -72,6 +73,7 @@ class ArtifactRegistry extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://artifactregistry.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://artifactregistry.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Assuredworkloads.php
+++ b/src/Assuredworkloads.php
@@ -41,6 +41,7 @@ class Assuredworkloads extends \Google\Service
   public $organizations_locations_operations;
   public $organizations_locations_workloads;
   public $organizations_locations_workloads_violations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Assuredworkloads service.
@@ -53,6 +54,7 @@ class Assuredworkloads extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://assuredworkloads.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://assuredworkloads.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/AuthorizedBuyersMarketplace.php
+++ b/src/AuthorizedBuyersMarketplace.php
@@ -48,6 +48,7 @@ class AuthorizedBuyersMarketplace extends \Google\Service
   public $buyers_proposals;
   public $buyers_proposals_deals;
   public $buyers_publisherProfiles;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the AuthorizedBuyersMarketplace
@@ -61,6 +62,7 @@ class AuthorizedBuyersMarketplace extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://authorizedbuyersmarketplace.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://authorizedbuyersmarketplace.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BackupforGKE.php
+++ b/src/BackupforGKE.php
@@ -47,6 +47,7 @@ class BackupforGKE extends \Google\Service
   public $projects_locations_restorePlans;
   public $projects_locations_restorePlans_restores;
   public $projects_locations_restorePlans_restores_volumeRestores;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BackupforGKE service.
@@ -59,6 +60,7 @@ class BackupforGKE extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gkebackup.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gkebackup.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Baremetalsolution.php
+++ b/src/Baremetalsolution.php
@@ -51,6 +51,7 @@ class Baremetalsolution extends \Google\Service
   public $projects_locations_volumes;
   public $projects_locations_volumes_luns;
   public $projects_locations_volumes_snapshots;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Baremetalsolution service.
@@ -63,6 +64,7 @@ class Baremetalsolution extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://baremetalsolution.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://baremetalsolution.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Batch.php
+++ b/src/Batch.php
@@ -43,6 +43,7 @@ class Batch extends \Google\Service
   public $projects_locations_jobs_taskGroups_tasks;
   public $projects_locations_operations;
   public $projects_locations_state;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Batch service.
@@ -55,6 +56,7 @@ class Batch extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://batch.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://batch.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BeyondCorp.php
+++ b/src/BeyondCorp.php
@@ -52,6 +52,7 @@ class BeyondCorp extends \Google\Service
   public $projects_locations_clientConnectorServices;
   public $projects_locations_clientGateways;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BeyondCorp service.
@@ -64,6 +65,7 @@ class BeyondCorp extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://beyondcorp.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://beyondcorp.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BigQueryConnectionService.php
+++ b/src/BigQueryConnectionService.php
@@ -42,6 +42,7 @@ class BigQueryConnectionService extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $projects_locations_connections;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BigQueryConnectionService
@@ -55,6 +56,7 @@ class BigQueryConnectionService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://bigqueryconnection.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://bigqueryconnection.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BigQueryDataTransfer.php
+++ b/src/BigQueryDataTransfer.php
@@ -55,6 +55,7 @@ class BigQueryDataTransfer extends \Google\Service
   public $projects_transferConfigs;
   public $projects_transferConfigs_runs;
   public $projects_transferConfigs_runs_transferLogs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BigQueryDataTransfer service.
@@ -67,6 +68,7 @@ class BigQueryDataTransfer extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://bigquerydatatransfer.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://bigquerydatatransfer.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BigQueryReservation.php
+++ b/src/BigQueryReservation.php
@@ -45,6 +45,7 @@ class BigQueryReservation extends \Google\Service
   public $projects_locations_capacityCommitments;
   public $projects_locations_reservations;
   public $projects_locations_reservations_assignments;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BigQueryReservation service.
@@ -57,6 +58,7 @@ class BigQueryReservation extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://bigqueryreservation.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://bigqueryreservation.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Bigquery.php
+++ b/src/Bigquery.php
@@ -64,6 +64,7 @@ class Bigquery extends \Google\Service
   public $rowAccessPolicies;
   public $tabledata;
   public $tables;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Bigquery service.
@@ -76,6 +77,7 @@ class Bigquery extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://bigquery.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://bigquery.UNIVERSE_DOMAIN/';
     $this->servicePath = 'bigquery/v2/';
     $this->batchPath = 'batch/bigquery/v2';
     $this->version = 'v2';

--- a/src/BigtableAdmin.php
+++ b/src/BigtableAdmin.php
@@ -72,6 +72,7 @@ class BigtableAdmin extends \Google\Service
   public $projects_instances_tables;
   public $projects_instances_tables_authorizedViews;
   public $projects_locations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BigtableAdmin service.
@@ -84,6 +85,7 @@ class BigtableAdmin extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://bigtableadmin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://bigtableadmin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/BinaryAuthorization.php
+++ b/src/BinaryAuthorization.php
@@ -46,6 +46,7 @@ class BinaryAuthorization extends \Google\Service
   public $projects_platforms_policies;
   public $projects_policy;
   public $systempolicy;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BinaryAuthorization service.
@@ -58,6 +59,7 @@ class BinaryAuthorization extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://binaryauthorization.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://binaryauthorization.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Blogger.php
+++ b/src/Blogger.php
@@ -50,6 +50,7 @@ class Blogger extends \Google\Service
   public $postUserInfos;
   public $posts;
   public $users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Blogger service.
@@ -62,6 +63,7 @@ class Blogger extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://blogger.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://blogger.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/Books.php
+++ b/src/Books.php
@@ -62,6 +62,7 @@ class Books extends \Google\Service
   public $volumes_mybooks;
   public $volumes_recommended;
   public $volumes_useruploaded;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Books service.
@@ -74,6 +75,7 @@ class Books extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://books.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://books.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/BusinessProfilePerformance.php
+++ b/src/BusinessProfilePerformance.php
@@ -40,6 +40,7 @@ class BusinessProfilePerformance extends \Google\Service
 
   public $locations;
   public $locations_searchkeywords_impressions_monthly;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the BusinessProfilePerformance
@@ -53,6 +54,7 @@ class BusinessProfilePerformance extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://businessprofileperformance.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://businessprofileperformance.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -58,6 +58,7 @@ class Calendar extends \Google\Service
   public $events;
   public $freebusy;
   public $settings;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Calendar service.
@@ -70,6 +71,7 @@ class Calendar extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'calendar/v3/';
     $this->batchPath = 'batch/calendar/v3';
     $this->version = 'v3';

--- a/src/CertificateAuthorityService.php
+++ b/src/CertificateAuthorityService.php
@@ -47,6 +47,7 @@ class CertificateAuthorityService extends \Google\Service
   public $projects_locations_caPools_certificates;
   public $projects_locations_certificateTemplates;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CertificateAuthorityService
@@ -60,6 +61,7 @@ class CertificateAuthorityService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://privateca.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://privateca.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CertificateManager.php
+++ b/src/CertificateManager.php
@@ -46,6 +46,7 @@ class CertificateManager extends \Google\Service
   public $projects_locations_dnsAuthorizations;
   public $projects_locations_operations;
   public $projects_locations_trustConfigs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CertificateManager service.
@@ -58,6 +59,7 @@ class CertificateManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://certificatemanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://certificatemanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ChromeManagement.php
+++ b/src/ChromeManagement.php
@@ -55,6 +55,7 @@ class ChromeManagement extends \Google\Service
   public $customers_telemetry_events;
   public $customers_telemetry_notificationConfigs;
   public $customers_telemetry_users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ChromeManagement service.
@@ -67,6 +68,7 @@ class ChromeManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://chromemanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://chromemanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ChromePolicy.php
+++ b/src/ChromePolicy.php
@@ -49,6 +49,7 @@ class ChromePolicy extends \Google\Service
   public $customers_policies_orgunits;
   public $customers_policySchemas;
   public $media;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ChromePolicy service.
@@ -61,6 +62,7 @@ class ChromePolicy extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://chromepolicy.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://chromepolicy.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ChromeUXReport.php
+++ b/src/ChromeUXReport.php
@@ -38,6 +38,7 @@ class ChromeUXReport extends \Google\Service
 
 
   public $records;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ChromeUXReport service.
@@ -50,6 +51,7 @@ class ChromeUXReport extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://chromeuxreport.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://chromeuxreport.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CivicInfo.php
+++ b/src/CivicInfo.php
@@ -40,6 +40,7 @@ class CivicInfo extends \Google\Service
   public $divisions;
   public $elections;
   public $representatives;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CivicInfo service.
@@ -52,6 +53,7 @@ class CivicInfo extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://civicinfo.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://civicinfo.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Classroom.php
+++ b/src/Classroom.php
@@ -115,6 +115,7 @@ class Classroom extends \Google\Service
   public $userProfiles;
   public $userProfiles_guardianInvitations;
   public $userProfiles_guardians;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Classroom service.
@@ -127,6 +128,7 @@ class Classroom extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://classroom.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://classroom.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudAsset.php
+++ b/src/CloudAsset.php
@@ -45,6 +45,7 @@ class CloudAsset extends \Google\Service
   public $operations;
   public $savedQueries;
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudAsset service.
@@ -57,6 +58,7 @@ class CloudAsset extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudasset.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudasset.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudBillingBudget.php
+++ b/src/CloudBillingBudget.php
@@ -43,6 +43,7 @@ class CloudBillingBudget extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $billingAccounts_budgets;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudBillingBudget service.
@@ -55,6 +56,7 @@ class CloudBillingBudget extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://billingbudgets.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://billingbudgets.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudBuild.php
+++ b/src/CloudBuild.php
@@ -42,6 +42,7 @@ class CloudBuild extends \Google\Service
   public $projects_locations_connections;
   public $projects_locations_connections_repositories;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudBuild service.
@@ -54,6 +55,7 @@ class CloudBuild extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudbuild.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudbuild.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudComposer.php
+++ b/src/CloudComposer.php
@@ -44,6 +44,7 @@ class CloudComposer extends \Google\Service
   public $projects_locations_environments_workloads;
   public $projects_locations_imageVersions;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudComposer service.
@@ -56,6 +57,7 @@ class CloudComposer extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://composer.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://composer.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudDataplex.php
+++ b/src/CloudDataplex.php
@@ -64,6 +64,7 @@ class CloudDataplex extends \Google\Service
   public $projects_locations_lakes_zones_entities;
   public $projects_locations_lakes_zones_entities_partitions;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudDataplex service.
@@ -76,6 +77,7 @@ class CloudDataplex extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dataplex.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dataplex.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudDeploy.php
+++ b/src/CloudDeploy.php
@@ -48,6 +48,7 @@ class CloudDeploy extends \Google\Service
   public $projects_locations_deliveryPipelines_releases_rollouts_jobRuns;
   public $projects_locations_operations;
   public $projects_locations_targets;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudDeploy service.
@@ -60,6 +61,7 @@ class CloudDeploy extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://clouddeploy.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://clouddeploy.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudDomains.php
+++ b/src/CloudDomains.php
@@ -41,6 +41,7 @@ class CloudDomains extends \Google\Service
   public $projects_locations;
   public $projects_locations_operations;
   public $projects_locations_registrations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudDomains service.
@@ -53,6 +54,7 @@ class CloudDomains extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://domains.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://domains.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudFilestore.php
+++ b/src/CloudFilestore.php
@@ -43,6 +43,7 @@ class CloudFilestore extends \Google\Service
   public $projects_locations_instances;
   public $projects_locations_instances_snapshots;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudFilestore service.
@@ -55,6 +56,7 @@ class CloudFilestore extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://file.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://file.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudFunctions.php
+++ b/src/CloudFunctions.php
@@ -42,6 +42,7 @@ class CloudFunctions extends \Google\Service
   public $projects_locations_functions;
   public $projects_locations_operations;
   public $projects_locations_runtimes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudFunctions service.
@@ -54,6 +55,7 @@ class CloudFunctions extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudfunctions.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudfunctions.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudHealthcare.php
+++ b/src/CloudHealthcare.php
@@ -62,6 +62,7 @@ class CloudHealthcare extends \Google\Service
   public $projects_locations_datasets_hl7V2Stores_messages;
   public $projects_locations_datasets_operations;
   public $projects_locations_services_nlp;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudHealthcare service.
@@ -74,6 +75,7 @@ class CloudHealthcare extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://healthcare.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://healthcare.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudIAP.php
+++ b/src/CloudIAP.php
@@ -42,6 +42,7 @@ class CloudIAP extends \Google\Service
   public $projects_brands_identityAwareProxyClients;
   public $projects_iap_tunnel_locations_destGroups;
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudIAP service.
@@ -54,6 +55,7 @@ class CloudIAP extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://iap.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://iap.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudIdentity.php
+++ b/src/CloudIdentity.php
@@ -62,6 +62,7 @@ class CloudIdentity extends \Google\Service
   public $inboundSamlSsoProfiles;
   public $inboundSamlSsoProfiles_idpCredentials;
   public $inboundSsoAssignments;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudIdentity service.
@@ -74,6 +75,7 @@ class CloudIdentity extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudidentity.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudidentity.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudKMS.php
+++ b/src/CloudKMS.php
@@ -49,6 +49,7 @@ class CloudKMS extends \Google\Service
   public $projects_locations_keyRings_cryptoKeys;
   public $projects_locations_keyRings_cryptoKeys_cryptoKeyVersions;
   public $projects_locations_keyRings_importJobs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudKMS service.
@@ -61,6 +62,7 @@ class CloudKMS extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudkms.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudkms.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudLifeSciences.php
+++ b/src/CloudLifeSciences.php
@@ -42,6 +42,7 @@ class CloudLifeSciences extends \Google\Service
   public $projects_locations;
   public $projects_locations_operations;
   public $projects_locations_pipelines;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudLifeSciences service.
@@ -54,6 +55,7 @@ class CloudLifeSciences extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://lifesciences.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://lifesciences.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2beta';

--- a/src/CloudMachineLearningEngine.php
+++ b/src/CloudMachineLearningEngine.php
@@ -50,6 +50,7 @@ class CloudMachineLearningEngine extends \Google\Service
   public $projects_models;
   public $projects_models_versions;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudMachineLearningEngine
@@ -63,6 +64,7 @@ class CloudMachineLearningEngine extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://ml.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://ml.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudMemorystoreforMemcached.php
+++ b/src/CloudMemorystoreforMemcached.php
@@ -42,6 +42,7 @@ class CloudMemorystoreforMemcached extends \Google\Service
   public $projects_locations;
   public $projects_locations_instances;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudMemorystoreforMemcached
@@ -55,6 +56,7 @@ class CloudMemorystoreforMemcached extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://memcache.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://memcache.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudNaturalLanguage.php
+++ b/src/CloudNaturalLanguage.php
@@ -44,6 +44,7 @@ class CloudNaturalLanguage extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $documents;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudNaturalLanguage service.
@@ -56,6 +57,7 @@ class CloudNaturalLanguage extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://language.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://language.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudOSLogin.php
+++ b/src/CloudOSLogin.php
@@ -50,6 +50,7 @@ class CloudOSLogin extends \Google\Service
   public $users;
   public $users_projects;
   public $users_sshPublicKeys;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudOSLogin service.
@@ -62,6 +63,7 @@ class CloudOSLogin extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://oslogin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://oslogin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudProfiler.php
+++ b/src/CloudProfiler.php
@@ -45,6 +45,7 @@ class CloudProfiler extends \Google\Service
       "https://www.googleapis.com/auth/monitoring.write";
 
   public $projects_profiles;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudProfiler service.
@@ -57,6 +58,7 @@ class CloudProfiler extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudprofiler.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudprofiler.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudRedis.php
+++ b/src/CloudRedis.php
@@ -42,6 +42,7 @@ class CloudRedis extends \Google\Service
   public $projects_locations_clusters;
   public $projects_locations_instances;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudRedis service.
@@ -54,6 +55,7 @@ class CloudRedis extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://redis.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://redis.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudResourceManager.php
+++ b/src/CloudResourceManager.php
@@ -52,6 +52,7 @@ class CloudResourceManager extends \Google\Service
   public $tagKeys;
   public $tagValues;
   public $tagValues_tagHolds;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudResourceManager service.
@@ -64,6 +65,7 @@ class CloudResourceManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudresourcemanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudresourcemanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/CloudRetail.php
+++ b/src/CloudRetail.php
@@ -54,6 +54,7 @@ class CloudRetail extends \Google\Service
   public $projects_locations_catalogs_userEvents;
   public $projects_locations_operations;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudRetail service.
@@ -66,6 +67,7 @@ class CloudRetail extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://retail.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://retail.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudRun.php
+++ b/src/CloudRun.php
@@ -48,6 +48,7 @@ class CloudRun extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_services;
   public $projects_locations_services_revisions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudRun service.
@@ -60,6 +61,7 @@ class CloudRun extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://run.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://run.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudRuntimeConfig.php
+++ b/src/CloudRuntimeConfig.php
@@ -45,6 +45,7 @@ class CloudRuntimeConfig extends \Google\Service
       "https://www.googleapis.com/auth/cloudruntimeconfig";
 
   public $operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudRuntimeConfig service.
@@ -57,6 +58,7 @@ class CloudRuntimeConfig extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://runtimeconfig.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://runtimeconfig.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudScheduler.php
+++ b/src/CloudScheduler.php
@@ -40,6 +40,7 @@ class CloudScheduler extends \Google\Service
 
   public $projects_locations;
   public $projects_locations_jobs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudScheduler service.
@@ -52,6 +53,7 @@ class CloudScheduler extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudscheduler.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudscheduler.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudSearch.php
+++ b/src/CloudSearch.php
@@ -84,6 +84,7 @@ class CloudSearch extends \Google\Service
   public $stats_session_searchapplications;
   public $stats_user_searchapplications;
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudSearch service.
@@ -96,6 +97,7 @@ class CloudSearch extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudsearch.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudsearch.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudSecurityToken.php
+++ b/src/CloudSecurityToken.php
@@ -38,6 +38,7 @@ class CloudSecurityToken extends \Google\Service
 
 
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudSecurityToken service.
@@ -50,6 +51,7 @@ class CloudSecurityToken extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://sts.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://sts.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudShell.php
+++ b/src/CloudShell.php
@@ -41,6 +41,7 @@ class CloudShell extends \Google\Service
 
   public $operations;
   public $users_environments;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudShell service.
@@ -53,6 +54,7 @@ class CloudShell extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudshell.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudshell.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudSourceRepositories.php
+++ b/src/CloudSourceRepositories.php
@@ -49,6 +49,7 @@ class CloudSourceRepositories extends \Google\Service
 
   public $projects;
   public $projects_repos;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudSourceRepositories
@@ -62,6 +63,7 @@ class CloudSourceRepositories extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://sourcerepo.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://sourcerepo.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CloudSupport.php
+++ b/src/CloudSupport.php
@@ -44,6 +44,7 @@ class CloudSupport extends \Google\Service
   public $cases_attachments;
   public $cases_comments;
   public $media;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudSupport service.
@@ -56,6 +57,7 @@ class CloudSupport extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudsupport.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudsupport.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudTalentSolution.php
+++ b/src/CloudTalentSolution.php
@@ -47,6 +47,7 @@ class CloudTalentSolution extends \Google\Service
   public $projects_tenants_clientEvents;
   public $projects_tenants_companies;
   public $projects_tenants_jobs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudTalentSolution service.
@@ -59,6 +60,7 @@ class CloudTalentSolution extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://jobs.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://jobs.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v4';

--- a/src/CloudTasks.php
+++ b/src/CloudTasks.php
@@ -41,6 +41,7 @@ class CloudTasks extends \Google\Service
   public $projects_locations;
   public $projects_locations_queues;
   public $projects_locations_queues_tasks;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudTasks service.
@@ -53,6 +54,7 @@ class CloudTasks extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudtasks.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudtasks.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudTrace.php
+++ b/src/CloudTrace.php
@@ -47,6 +47,7 @@ class CloudTrace extends \Google\Service
 
   public $projects_traces;
   public $projects_traces_spans;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudTrace service.
@@ -59,6 +60,7 @@ class CloudTrace extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudtrace.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudtrace.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/CloudVideoIntelligence.php
+++ b/src/CloudVideoIntelligence.php
@@ -43,6 +43,7 @@ class CloudVideoIntelligence extends \Google\Service
   public $operations_projects_locations_operations;
   public $projects_locations_operations;
   public $videos;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CloudVideoIntelligence
@@ -56,6 +57,7 @@ class CloudVideoIntelligence extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://videointelligence.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://videointelligence.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Cloudbilling.php
+++ b/src/Cloudbilling.php
@@ -52,6 +52,7 @@ class Cloudbilling extends \Google\Service
   public $projects;
   public $services;
   public $services_skus;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Cloudbilling service.
@@ -64,6 +65,7 @@ class Cloudbilling extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudbilling.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudbilling.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Cloudchannel.php
+++ b/src/Cloudchannel.php
@@ -58,6 +58,7 @@ class Cloudchannel extends \Google\Service
   public $operations;
   public $products;
   public $products_skus;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Cloudchannel service.
@@ -70,6 +71,7 @@ class Cloudchannel extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://cloudchannel.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://cloudchannel.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Clouderrorreporting.php
+++ b/src/Clouderrorreporting.php
@@ -44,6 +44,7 @@ class Clouderrorreporting extends \Google\Service
   public $projects_events;
   public $projects_groupStats;
   public $projects_groups;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Clouderrorreporting service.
@@ -56,6 +57,7 @@ class Clouderrorreporting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://clouderrorreporting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://clouderrorreporting.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/Compute.php
+++ b/src/Compute.php
@@ -153,6 +153,7 @@ class Compute extends \Google\Service
   public $vpnTunnels;
   public $zoneOperations;
   public $zones;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Compute service.
@@ -165,6 +166,7 @@ class Compute extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://compute.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://compute.UNIVERSE_DOMAIN/';
     $this->servicePath = 'compute/v1/';
     $this->batchPath = 'batch/compute/v1';
     $this->version = 'v1';

--- a/src/Connectors.php
+++ b/src/Connectors.php
@@ -43,6 +43,7 @@ class Connectors extends \Google\Service
   public $projects_locations_connections_actions;
   public $projects_locations_connections_entityTypes;
   public $projects_locations_connections_entityTypes_entities;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Connectors service.
@@ -55,6 +56,7 @@ class Connectors extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://connectors.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://connectors.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Contactcenterinsights.php
+++ b/src/Contactcenterinsights.php
@@ -47,6 +47,7 @@ class Contactcenterinsights extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_phraseMatchers;
   public $projects_locations_views;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Contactcenterinsights
@@ -60,6 +61,7 @@ class Contactcenterinsights extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://contactcenterinsights.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://contactcenterinsights.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Container.php
+++ b/src/Container.php
@@ -49,6 +49,7 @@ class Container extends \Google\Service
   public $projects_zones_clusters;
   public $projects_zones_clusters_nodePools;
   public $projects_zones_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Container service.
@@ -61,6 +62,7 @@ class Container extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://container.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://container.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ContainerAnalysis.php
+++ b/src/ContainerAnalysis.php
@@ -50,6 +50,7 @@ class ContainerAnalysis extends \Google\Service
   public $projects_notes_occurrences;
   public $projects_occurrences;
   public $projects_resources;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ContainerAnalysis service.
@@ -62,6 +63,7 @@ class ContainerAnalysis extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://containeranalysis.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://containeranalysis.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Contentwarehouse.php
+++ b/src/Contentwarehouse.php
@@ -47,6 +47,7 @@ class Contentwarehouse extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_ruleSets;
   public $projects_locations_synonymSets;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Contentwarehouse service.
@@ -59,6 +60,7 @@ class Contentwarehouse extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://contentwarehouse.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://contentwarehouse.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/CustomSearchAPI.php
+++ b/src/CustomSearchAPI.php
@@ -38,6 +38,7 @@ class CustomSearchAPI extends \Google\Service
 
   public $cse;
   public $cse_siterestrict;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the CustomSearchAPI service.
@@ -50,6 +51,7 @@ class CustomSearchAPI extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://customsearch.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://customsearch.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DLP.php
+++ b/src/DLP.php
@@ -73,6 +73,7 @@ class DLP extends \Google\Service
   public $projects_locations_storedInfoTypes;
   public $projects_locations_tableDataProfiles;
   public $projects_storedInfoTypes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DLP service.
@@ -85,6 +86,7 @@ class DLP extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dlp.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dlp.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/DataCatalog.php
+++ b/src/DataCatalog.php
@@ -51,6 +51,7 @@ class DataCatalog extends \Google\Service
   public $projects_locations_tagTemplates_fields_enumValues;
   public $projects_locations_taxonomies;
   public $projects_locations_taxonomies_policyTags;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DataCatalog service.
@@ -63,6 +64,7 @@ class DataCatalog extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datacatalog.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datacatalog.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DataFusion.php
+++ b/src/DataFusion.php
@@ -49,6 +49,7 @@ class DataFusion extends \Google\Service
   public $projects_locations_instances_dnsPeerings;
   public $projects_locations_operations;
   public $projects_locations_versions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DataFusion service.
@@ -61,6 +62,7 @@ class DataFusion extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datafusion.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datafusion.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DataLabeling.php
+++ b/src/DataLabeling.php
@@ -55,6 +55,7 @@ class DataLabeling extends \Google\Service
   public $projects_evaluations;
   public $projects_instructions;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DataLabeling service.
@@ -67,6 +68,7 @@ class DataLabeling extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datalabeling.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datalabeling.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/DataTransfer.php
+++ b/src/DataTransfer.php
@@ -45,6 +45,7 @@ class DataTransfer extends \Google\Service
 
   public $applications;
   public $transfers;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DataTransfer service.
@@ -57,6 +58,7 @@ class DataTransfer extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://admin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://admin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'datatransfer_v1';

--- a/src/DatabaseMigrationService.php
+++ b/src/DatabaseMigrationService.php
@@ -45,6 +45,7 @@ class DatabaseMigrationService extends \Google\Service
   public $projects_locations_migrationJobs;
   public $projects_locations_operations;
   public $projects_locations_privateConnections;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DatabaseMigrationService
@@ -58,6 +59,7 @@ class DatabaseMigrationService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datamigration.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datamigration.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Dataflow.php
+++ b/src/Dataflow.php
@@ -61,6 +61,7 @@ class Dataflow extends \Google\Service
   public $projects_locations_templates;
   public $projects_snapshots;
   public $projects_templates;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Dataflow service.
@@ -73,6 +74,7 @@ class Dataflow extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dataflow.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dataflow.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1b3';

--- a/src/Datapipelines.php
+++ b/src/Datapipelines.php
@@ -41,6 +41,7 @@ class Datapipelines extends \Google\Service
 
   public $projects_locations_pipelines;
   public $projects_locations_pipelines_jobs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Datapipelines service.
@@ -53,6 +54,7 @@ class Datapipelines extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datapipelines.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datapipelines.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Dataproc.php
+++ b/src/Dataproc.php
@@ -50,6 +50,7 @@ class Dataproc extends \Google\Service
   public $projects_regions_jobs;
   public $projects_regions_operations;
   public $projects_regions_workflowTemplates;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Dataproc service.
@@ -62,6 +63,7 @@ class Dataproc extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dataproc.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dataproc.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DataprocMetastore.php
+++ b/src/DataprocMetastore.php
@@ -45,6 +45,7 @@ class DataprocMetastore extends \Google\Service
   public $projects_locations_services;
   public $projects_locations_services_backups;
   public $projects_locations_services_metadataImports;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DataprocMetastore service.
@@ -57,6 +58,7 @@ class DataprocMetastore extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://metastore.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://metastore.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Datastore.php
+++ b/src/Datastore.php
@@ -45,6 +45,7 @@ class Datastore extends \Google\Service
   public $projects;
   public $projects_indexes;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Datastore service.
@@ -57,6 +58,7 @@ class Datastore extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datastore.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datastore.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Datastream.php
+++ b/src/Datastream.php
@@ -45,6 +45,7 @@ class Datastream extends \Google\Service
   public $projects_locations_privateConnections_routes;
   public $projects_locations_streams;
   public $projects_locations_streams_objects;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Datastream service.
@@ -57,6 +58,7 @@ class Datastream extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://datastream.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://datastream.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DeploymentManager.php
+++ b/src/DeploymentManager.php
@@ -54,6 +54,7 @@ class DeploymentManager extends \Google\Service
   public $operations;
   public $resources;
   public $types;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DeploymentManager service.
@@ -66,6 +67,7 @@ class DeploymentManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://deploymentmanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://deploymentmanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Dfareporting.php
+++ b/src/Dfareporting.php
@@ -110,6 +110,7 @@ class Dfareporting extends \Google\Service
   public $userRolePermissions;
   public $userRoles;
   public $videoFormats;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Dfareporting service.
@@ -122,6 +123,7 @@ class Dfareporting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dfareporting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dfareporting.UNIVERSE_DOMAIN/';
     $this->servicePath = 'dfareporting/v4/';
     $this->batchPath = 'batch';
     $this->version = 'v4';

--- a/src/Dialogflow.php
+++ b/src/Dialogflow.php
@@ -67,6 +67,7 @@ class Dialogflow extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_securitySettings;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Dialogflow service.
@@ -79,6 +80,7 @@ class Dialogflow extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dialogflow.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dialogflow.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/Digitalassetlinks.php
+++ b/src/Digitalassetlinks.php
@@ -39,6 +39,7 @@ class Digitalassetlinks extends \Google\Service
 
   public $assetlinks;
   public $statements;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Digitalassetlinks service.
@@ -51,6 +52,7 @@ class Digitalassetlinks extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://digitalassetlinks.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://digitalassetlinks.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -152,6 +152,7 @@ class Directory extends \Google\Service
   public $users_aliases;
   public $users_photos;
   public $verificationCodes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Directory service.
@@ -164,6 +165,7 @@ class Directory extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://admin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://admin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'directory_v1';

--- a/src/DiscoveryEngine.php
+++ b/src/DiscoveryEngine.php
@@ -74,6 +74,7 @@ class DiscoveryEngine extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_userEvents;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DiscoveryEngine service.

--- a/src/DisplayVideo.php
+++ b/src/DisplayVideo.php
@@ -91,6 +91,7 @@ class DisplayVideo extends \Google\Service
   public $sdfdownloadtasks_operations;
   public $targetingTypes_targetingOptions;
   public $users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DisplayVideo service.
@@ -103,6 +104,7 @@ class DisplayVideo extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://displayvideo.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://displayvideo.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/Dns.php
+++ b/src/Dns.php
@@ -56,6 +56,7 @@ class Dns extends \Google\Service
   public $resourceRecordSets;
   public $responsePolicies;
   public $responsePolicyRules;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Dns service.
@@ -68,6 +69,7 @@ class Dns extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://dns.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://dns.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Docs.php
+++ b/src/Docs.php
@@ -51,6 +51,7 @@ class Docs extends \Google\Service
       "https://www.googleapis.com/auth/drive.readonly";
 
   public $documents;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Docs service.
@@ -63,6 +64,7 @@ class Docs extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://docs.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://docs.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Document.php
+++ b/src/Document.php
@@ -49,6 +49,7 @@ class Document extends \Google\Service
   public $projects_locations_processors_processorVersions;
   public $projects_locations_processors_processorVersions_evaluations;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Document service.
@@ -61,6 +62,7 @@ class Document extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://documentai.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://documentai.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DomainsRDAP.php
+++ b/src/DomainsRDAP.php
@@ -43,6 +43,7 @@ class DomainsRDAP extends \Google\Service
   public $ip;
   public $nameserver;
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DomainsRDAP service.
@@ -55,6 +56,7 @@ class DomainsRDAP extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://domainsrdap.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://domainsrdap.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/DoubleClickBidManager.php
+++ b/src/DoubleClickBidManager.php
@@ -41,6 +41,7 @@ class DoubleClickBidManager extends \Google\Service
 
   public $queries;
   public $queries_reports;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DoubleClickBidManager
@@ -54,6 +55,7 @@ class DoubleClickBidManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://doubleclickbidmanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://doubleclickbidmanager.UNIVERSE_DOMAIN/';
     $this->servicePath = 'v2/';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Doubleclicksearch.php
+++ b/src/Doubleclicksearch.php
@@ -42,6 +42,7 @@ class Doubleclicksearch extends \Google\Service
   public $conversion;
   public $reports;
   public $savedColumns;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Doubleclicksearch service.
@@ -54,6 +55,7 @@ class Doubleclicksearch extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://doubleclicksearch.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://doubleclicksearch.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Drive.php
+++ b/src/Drive.php
@@ -73,6 +73,7 @@ class Drive extends \Google\Service
   public $replies;
   public $revisions;
   public $teamdrives;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Drive service.
@@ -85,6 +86,7 @@ class Drive extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'drive/v3/';
     $this->batchPath = 'batch/drive/v3';
     $this->version = 'v3';

--- a/src/DriveActivity.php
+++ b/src/DriveActivity.php
@@ -42,6 +42,7 @@ class DriveActivity extends \Google\Service
       "https://www.googleapis.com/auth/drive.activity.readonly";
 
   public $activity;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DriveActivity service.
@@ -54,6 +55,7 @@ class DriveActivity extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://driveactivity.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://driveactivity.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/DriveLabels.php
+++ b/src/DriveLabels.php
@@ -55,6 +55,7 @@ class DriveLabels extends \Google\Service
   public $labels_revisions_permissions;
   public $limits;
   public $users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the DriveLabels service.
@@ -67,6 +68,7 @@ class DriveLabels extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://drivelabels.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://drivelabels.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Essentialcontacts.php
+++ b/src/Essentialcontacts.php
@@ -41,6 +41,7 @@ class Essentialcontacts extends \Google\Service
   public $folders_contacts;
   public $organizations_contacts;
   public $projects_contacts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Essentialcontacts service.
@@ -53,6 +54,7 @@ class Essentialcontacts extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://essentialcontacts.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://essentialcontacts.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Eventarc.php
+++ b/src/Eventarc.php
@@ -44,6 +44,7 @@ class Eventarc extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_providers;
   public $projects_locations_triggers;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Eventarc service.
@@ -56,6 +57,7 @@ class Eventarc extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://eventarc.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://eventarc.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/FactCheckTools.php
+++ b/src/FactCheckTools.php
@@ -40,6 +40,7 @@ class FactCheckTools extends \Google\Service
 
   public $claims;
   public $pages;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FactCheckTools service.
@@ -52,6 +53,7 @@ class FactCheckTools extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://factchecktools.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://factchecktools.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1alpha1';

--- a/src/Fcmdata.php
+++ b/src/Fcmdata.php
@@ -40,6 +40,7 @@ class Fcmdata extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $projects_androidApps_deliveryData;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Fcmdata service.
@@ -52,6 +53,7 @@ class Fcmdata extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://fcmdata.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://fcmdata.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/FirebaseCloudMessaging.php
+++ b/src/FirebaseCloudMessaging.php
@@ -43,6 +43,7 @@ class FirebaseCloudMessaging extends \Google\Service
       "https://www.googleapis.com/auth/firebase.messaging";
 
   public $projects_messages;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseCloudMessaging
@@ -56,6 +57,7 @@ class FirebaseCloudMessaging extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://fcm.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://fcm.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/FirebaseDynamicLinks.php
+++ b/src/FirebaseDynamicLinks.php
@@ -41,6 +41,7 @@ class FirebaseDynamicLinks extends \Google\Service
   public $managedShortLinks;
   public $shortLinks;
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseDynamicLinks service.
@@ -53,6 +54,7 @@ class FirebaseDynamicLinks extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebasedynamiclinks.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebasedynamiclinks.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/FirebaseHosting.php
+++ b/src/FirebaseHosting.php
@@ -46,6 +46,7 @@ class FirebaseHosting extends \Google\Service
 
   public $operations;
   public $projects_sites_customDomains_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseHosting service.
@@ -58,6 +59,7 @@ class FirebaseHosting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebasehosting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebasehosting.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/FirebaseML.php
+++ b/src/FirebaseML.php
@@ -39,6 +39,7 @@ class FirebaseML extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseML service.
@@ -51,6 +52,7 @@ class FirebaseML extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebaseml.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebaseml.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/FirebaseManagement.php
+++ b/src/FirebaseManagement.php
@@ -58,6 +58,7 @@ class FirebaseManagement extends \Google\Service
   public $projects_defaultLocation;
   public $projects_iosApps;
   public $projects_webApps;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseManagement service.
@@ -70,6 +71,7 @@ class FirebaseManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebase.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebase.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/FirebaseRealtimeDatabase.php
+++ b/src/FirebaseRealtimeDatabase.php
@@ -49,6 +49,7 @@ class FirebaseRealtimeDatabase extends \Google\Service
       "https://www.googleapis.com/auth/firebase.readonly";
 
   public $projects_locations_instances;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseRealtimeDatabase
@@ -62,6 +63,7 @@ class FirebaseRealtimeDatabase extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebasedatabase.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebasedatabase.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta';

--- a/src/FirebaseRules.php
+++ b/src/FirebaseRules.php
@@ -48,6 +48,7 @@ class FirebaseRules extends \Google\Service
   public $projects;
   public $projects_releases;
   public $projects_rulesets;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the FirebaseRules service.
@@ -60,6 +61,7 @@ class FirebaseRules extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebaserules.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebaserules.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Firebaseappcheck.php
+++ b/src/Firebaseappcheck.php
@@ -52,6 +52,7 @@ class Firebaseappcheck extends \Google\Service
   public $projects_apps_recaptchaV3Config;
   public $projects_apps_safetyNetConfig;
   public $projects_services;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Firebaseappcheck service.
@@ -64,6 +65,7 @@ class Firebaseappcheck extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebaseappcheck.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebaseappcheck.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Firebasestorage.php
+++ b/src/Firebasestorage.php
@@ -43,6 +43,7 @@ class Firebasestorage extends \Google\Service
       "https://www.googleapis.com/auth/firebase";
 
   public $projects_buckets;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Firebasestorage service.
@@ -55,6 +56,7 @@ class Firebasestorage extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firebasestorage.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firebasestorage.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta';

--- a/src/Firestore.php
+++ b/src/Firestore.php
@@ -50,6 +50,7 @@ class Firestore extends \Google\Service
   public $projects_databases_operations;
   public $projects_locations;
   public $projects_locations_backups;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Firestore service.
@@ -62,6 +63,7 @@ class Firestore extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://firestore.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://firestore.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Fitness.php
+++ b/src/Fitness.php
@@ -106,6 +106,7 @@ class Fitness extends \Google\Service
   public $users_dataSources_datasets;
   public $users_dataset;
   public $users_sessions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Fitness service.
@@ -118,6 +119,7 @@ class Fitness extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://fitness.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://fitness.UNIVERSE_DOMAIN/';
     $this->servicePath = 'fitness/v1/users/';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Forms.php
+++ b/src/Forms.php
@@ -56,6 +56,7 @@ class Forms extends \Google\Service
   public $forms;
   public $forms_responses;
   public $forms_watches;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Forms service.
@@ -68,6 +69,7 @@ class Forms extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://forms.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://forms.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/GKEHub.php
+++ b/src/GKEHub.php
@@ -48,6 +48,7 @@ class GKEHub extends \Google\Service
   public $projects_locations_scopes;
   public $projects_locations_scopes_namespaces;
   public $projects_locations_scopes_rbacrolebindings;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the GKEHub service.
@@ -60,6 +61,7 @@ class GKEHub extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gkehub.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gkehub.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Games.php
+++ b/src/Games.php
@@ -57,6 +57,7 @@ class Games extends \Google\Service
   public $scores;
   public $snapshots;
   public $stats;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Games service.
@@ -69,6 +70,7 @@ class Games extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://games.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://games.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/GamesConfiguration.php
+++ b/src/GamesConfiguration.php
@@ -41,6 +41,7 @@ class GamesConfiguration extends \Google\Service
 
   public $achievementConfigurations;
   public $leaderboardConfigurations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the GamesConfiguration service.
@@ -53,6 +54,7 @@ class GamesConfiguration extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gamesconfiguration.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gamesconfiguration.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1configuration';

--- a/src/GamesManagement.php
+++ b/src/GamesManagement.php
@@ -44,6 +44,7 @@ class GamesManagement extends \Google\Service
   public $events;
   public $players;
   public $scores;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the GamesManagement service.
@@ -56,6 +57,7 @@ class GamesManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gamesmanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gamesmanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1management';

--- a/src/Gmail.php
+++ b/src/Gmail.php
@@ -93,6 +93,7 @@ class Gmail extends \Google\Service
   public $users_settings_sendAs;
   public $users_settings_sendAs_smimeInfo;
   public $users_threads;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Gmail service.
@@ -105,6 +106,7 @@ class Gmail extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gmail.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gmail.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/GoogleAnalyticsAdmin.php
+++ b/src/GoogleAnalyticsAdmin.php
@@ -58,6 +58,7 @@ class GoogleAnalyticsAdmin extends \Google\Service
   public $properties_firebaseLinks;
   public $properties_googleAdsLinks;
   public $properties_keyEvents;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the GoogleAnalyticsAdmin service.
@@ -70,6 +71,7 @@ class GoogleAnalyticsAdmin extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://analyticsadmin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://analyticsadmin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta';

--- a/src/GroupsMigration.php
+++ b/src/GroupsMigration.php
@@ -40,6 +40,7 @@ class GroupsMigration extends \Google\Service
       "https://www.googleapis.com/auth/apps.groups.migration";
 
   public $archive;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the GroupsMigration service.
@@ -52,6 +53,7 @@ class GroupsMigration extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://groupsmigration.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://groupsmigration.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Groupssettings.php
+++ b/src/Groupssettings.php
@@ -39,6 +39,7 @@ class Groupssettings extends \Google\Service
       "https://www.googleapis.com/auth/apps.groups.settings";
 
   public $groups;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Groupssettings service.
@@ -51,6 +52,7 @@ class Groupssettings extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'groups/v1/groups/';
     $this->batchPath = 'batch/groupssettings/v1';
     $this->version = 'v1';

--- a/src/HangoutsChat.php
+++ b/src/HangoutsChat.php
@@ -88,6 +88,7 @@ class HangoutsChat extends \Google\Service
   public $spaces_messages_attachments;
   public $spaces_messages_reactions;
   public $spaces_spaceEvents;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the HangoutsChat service.
@@ -100,6 +101,7 @@ class HangoutsChat extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://chat.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://chat.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/HomeGraphService.php
+++ b/src/HomeGraphService.php
@@ -40,6 +40,7 @@ class HomeGraphService extends \Google\Service
 
   public $agentUsers;
   public $devices;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the HomeGraphService service.
@@ -52,6 +53,7 @@ class HomeGraphService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://homegraph.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://homegraph.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/IAMCredentials.php
+++ b/src/IAMCredentials.php
@@ -41,6 +41,7 @@ class IAMCredentials extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $projects_serviceAccounts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the IAMCredentials service.
@@ -53,6 +54,7 @@ class IAMCredentials extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://iamcredentials.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://iamcredentials.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/IDS.php
+++ b/src/IDS.php
@@ -45,6 +45,7 @@ class IDS extends \Google\Service
   public $projects_locations;
   public $projects_locations_endpoints;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the IDS service.
@@ -57,6 +58,7 @@ class IDS extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://ids.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://ids.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Iam.php
+++ b/src/Iam.php
@@ -44,6 +44,7 @@ class Iam extends \Google\Service
 
   public $policies;
   public $policies_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Iam service.
@@ -56,6 +57,7 @@ class Iam extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://iam.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://iam.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/IdentityToolkit.php
+++ b/src/IdentityToolkit.php
@@ -42,6 +42,7 @@ class IdentityToolkit extends \Google\Service
       "https://www.googleapis.com/auth/firebase";
 
   public $relyingparty;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the IdentityToolkit service.
@@ -54,6 +55,7 @@ class IdentityToolkit extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'identitytoolkit/v3/relyingparty/';
     $this->batchPath = 'batch/identitytoolkit/v3';
     $this->version = 'v3';

--- a/src/Indexing.php
+++ b/src/Indexing.php
@@ -39,6 +39,7 @@ class Indexing extends \Google\Service
       "https://www.googleapis.com/auth/indexing";
 
   public $urlNotifications;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Indexing service.
@@ -51,6 +52,7 @@ class Indexing extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://indexing.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://indexing.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/Integrations.php
+++ b/src/Integrations.php
@@ -65,6 +65,7 @@ class Integrations extends \Google\Service
   public $projects_locations_products_sfdcInstances_sfdcChannels;
   public $projects_locations_sfdcInstances;
   public $projects_locations_sfdcInstances_sfdcChannels;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Integrations service.
@@ -77,6 +78,7 @@ class Integrations extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://integrations.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://integrations.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Keep.php
+++ b/src/Keep.php
@@ -45,6 +45,7 @@ class Keep extends \Google\Service
   public $media;
   public $notes;
   public $notes_permissions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Keep service.
@@ -57,6 +58,7 @@ class Keep extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://keep.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://keep.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Kgsearch.php
+++ b/src/Kgsearch.php
@@ -37,6 +37,7 @@ class Kgsearch extends \Google\Service
 
 
   public $entities;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Kgsearch service.
@@ -49,6 +50,7 @@ class Kgsearch extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://kgsearch.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://kgsearch.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Libraryagent.php
+++ b/src/Libraryagent.php
@@ -40,6 +40,7 @@ class Libraryagent extends \Google\Service
 
   public $shelves;
   public $shelves_books;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Libraryagent service.
@@ -52,6 +53,7 @@ class Libraryagent extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://libraryagent.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://libraryagent.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Licensing.php
+++ b/src/Licensing.php
@@ -40,6 +40,7 @@ class Licensing extends \Google\Service
       "https://www.googleapis.com/auth/apps.licensing";
 
   public $licenseAssignments;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Licensing service.
@@ -52,6 +53,7 @@ class Licensing extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://licensing.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://licensing.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Localservices.php
+++ b/src/Localservices.php
@@ -40,6 +40,7 @@ class Localservices extends \Google\Service
 
   public $accountReports;
   public $detailedLeadReports;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Localservices service.
@@ -52,6 +53,7 @@ class Localservices extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://localservices.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://localservices.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Logging.php
+++ b/src/Logging.php
@@ -110,6 +110,7 @@ class Logging extends \Google\Service
   public $projects_sinks;
   public $sinks;
   public $v2;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Logging service.
@@ -122,6 +123,7 @@ class Logging extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://logging.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://logging.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/ManufacturerCenter.php
+++ b/src/ManufacturerCenter.php
@@ -40,6 +40,7 @@ class ManufacturerCenter extends \Google\Service
 
   public $accounts_languages_productCertifications;
   public $accounts_products;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ManufacturerCenter service.
@@ -52,6 +53,7 @@ class ManufacturerCenter extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://manufacturers.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://manufacturers.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Monitoring.php
+++ b/src/Monitoring.php
@@ -63,6 +63,7 @@ class Monitoring extends \Google\Service
   public $services;
   public $services_serviceLevelObjectives;
   public $uptimeCheckIps;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Monitoring service.
@@ -75,6 +76,7 @@ class Monitoring extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://monitoring.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://monitoring.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/MyBusinessAccountManagement.php
+++ b/src/MyBusinessAccountManagement.php
@@ -43,6 +43,7 @@ class MyBusinessAccountManagement extends \Google\Service
   public $accounts_invitations;
   public $locations;
   public $locations_admins;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessAccountManagement
@@ -56,6 +57,7 @@ class MyBusinessAccountManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessaccountmanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessaccountmanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessBusinessInformation.php
+++ b/src/MyBusinessBusinessInformation.php
@@ -45,6 +45,7 @@ class MyBusinessBusinessInformation extends \Google\Service
   public $googleLocations;
   public $locations;
   public $locations_attributes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessBusinessInformation
@@ -58,6 +59,7 @@ class MyBusinessBusinessInformation extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessbusinessinformation.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessbusinessinformation.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessLodging.php
+++ b/src/MyBusinessLodging.php
@@ -40,6 +40,7 @@ class MyBusinessLodging extends \Google\Service
 
   public $locations;
   public $locations_lodging;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessLodging service.
@@ -52,6 +53,7 @@ class MyBusinessLodging extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinesslodging.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinesslodging.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessNotificationSettings.php
+++ b/src/MyBusinessNotificationSettings.php
@@ -39,6 +39,7 @@ class MyBusinessNotificationSettings extends \Google\Service
 
 
   public $accounts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the
@@ -52,6 +53,7 @@ class MyBusinessNotificationSettings extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessnotifications.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessnotifications.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessPlaceActions.php
+++ b/src/MyBusinessPlaceActions.php
@@ -40,6 +40,7 @@ class MyBusinessPlaceActions extends \Google\Service
 
   public $locations_placeActionLinks;
   public $placeActionTypeMetadata;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessPlaceActions
@@ -53,6 +54,7 @@ class MyBusinessPlaceActions extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessplaceactions.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessplaceactions.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessQA.php
+++ b/src/MyBusinessQA.php
@@ -40,6 +40,7 @@ class MyBusinessQA extends \Google\Service
 
   public $locations_questions;
   public $locations_questions_answers;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessQA service.
@@ -52,6 +53,7 @@ class MyBusinessQA extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessqanda.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessqanda.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/MyBusinessVerifications.php
+++ b/src/MyBusinessVerifications.php
@@ -39,6 +39,7 @@ class MyBusinessVerifications extends \Google\Service
 
   public $locations;
   public $locations_verifications;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the MyBusinessVerifications
@@ -52,6 +53,7 @@ class MyBusinessVerifications extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://mybusinessverifications.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://mybusinessverifications.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/NetworkManagement.php
+++ b/src/NetworkManagement.php
@@ -42,6 +42,7 @@ class NetworkManagement extends \Google\Service
   public $projects_locations;
   public $projects_locations_global_connectivityTests;
   public $projects_locations_global_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the NetworkManagement service.
@@ -54,6 +55,7 @@ class NetworkManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://networkmanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://networkmanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/NetworkSecurity.php
+++ b/src/NetworkSecurity.php
@@ -54,6 +54,7 @@ class NetworkSecurity extends \Google\Service
   public $projects_locations_serverTlsPolicies;
   public $projects_locations_tlsInspectionPolicies;
   public $projects_locations_urlLists;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the NetworkSecurity service.
@@ -66,6 +67,7 @@ class NetworkSecurity extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://networksecurity.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://networksecurity.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/NetworkServices.php
+++ b/src/NetworkServices.php
@@ -54,6 +54,7 @@ class NetworkServices extends \Google\Service
   public $projects_locations_serviceLbPolicies;
   public $projects_locations_tcpRoutes;
   public $projects_locations_tlsRoutes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the NetworkServices service.
@@ -66,6 +67,7 @@ class NetworkServices extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://networkservices.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://networkservices.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Networkconnectivity.php
+++ b/src/Networkconnectivity.php
@@ -51,6 +51,7 @@ class Networkconnectivity extends \Google\Service
   public $projects_locations_serviceConnectionPolicies;
   public $projects_locations_serviceConnectionTokens;
   public $projects_locations_spokes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Networkconnectivity service.
@@ -63,6 +64,7 @@ class Networkconnectivity extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://networkconnectivity.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://networkconnectivity.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/OSConfig.php
+++ b/src/OSConfig.php
@@ -48,6 +48,7 @@ class OSConfig extends \Google\Service
   public $projects_patchDeployments;
   public $projects_patchJobs;
   public $projects_patchJobs_instanceDetails;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the OSConfig service.
@@ -60,6 +61,7 @@ class OSConfig extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://osconfig.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://osconfig.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Oauth2.php
+++ b/src/Oauth2.php
@@ -47,6 +47,7 @@ class Oauth2 extends \Google\Service
 
   public $userinfo;
   public $userinfo_v2_me;
+  public $rootUrlTemplate;
   private $base_methods;
   /**
    * Constructs the internal representation of the Oauth2 service.
@@ -59,6 +60,7 @@ class Oauth2 extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch/oauth2/v2';
     $this->version = 'v2';

--- a/src/OnDemandScanning.php
+++ b/src/OnDemandScanning.php
@@ -41,6 +41,7 @@ class OnDemandScanning extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_scans;
   public $projects_locations_scans_vulnerabilities;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the OnDemandScanning service.
@@ -53,6 +54,7 @@ class OnDemandScanning extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://ondemandscanning.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://ondemandscanning.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/OrgPolicyAPI.php
+++ b/src/OrgPolicyAPI.php
@@ -46,6 +46,7 @@ class OrgPolicyAPI extends \Google\Service
   public $organizations_policies;
   public $projects_constraints;
   public $projects_policies;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the OrgPolicyAPI service.
@@ -58,6 +59,7 @@ class OrgPolicyAPI extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://orgpolicy.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://orgpolicy.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/PagespeedInsights.php
+++ b/src/PagespeedInsights.php
@@ -42,6 +42,7 @@ class PagespeedInsights extends \Google\Service
       "openid";
 
   public $pagespeedapi;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PagespeedInsights service.
@@ -54,6 +55,7 @@ class PagespeedInsights extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://pagespeedonline.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://pagespeedonline.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v5';

--- a/src/PaymentsResellerSubscription.php
+++ b/src/PaymentsResellerSubscription.php
@@ -41,6 +41,7 @@ class PaymentsResellerSubscription extends \Google\Service
   public $partners_products;
   public $partners_promotions;
   public $partners_subscriptions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PaymentsResellerSubscription
@@ -54,6 +55,7 @@ class PaymentsResellerSubscription extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://paymentsresellersubscription.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://paymentsresellersubscription.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PeopleService.php
+++ b/src/PeopleService.php
@@ -76,6 +76,7 @@ class PeopleService extends \Google\Service
   public $otherContacts;
   public $people;
   public $people_connections;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PeopleService service.
@@ -88,6 +89,7 @@ class PeopleService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://people.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://people.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PlayIntegrity.php
+++ b/src/PlayIntegrity.php
@@ -42,6 +42,7 @@ class PlayIntegrity extends \Google\Service
       "https://www.googleapis.com/auth/playintegrity";
 
   public $v1;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PlayIntegrity service.
@@ -54,6 +55,7 @@ class PlayIntegrity extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://playintegrity.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://playintegrity.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Playcustomapp.php
+++ b/src/Playcustomapp.php
@@ -39,6 +39,7 @@ class Playcustomapp extends \Google\Service
       "https://www.googleapis.com/auth/androidpublisher";
 
   public $accounts_customApps;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Playcustomapp service.
@@ -51,6 +52,7 @@ class Playcustomapp extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://playcustomapp.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://playcustomapp.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Playdeveloperreporting.php
+++ b/src/Playdeveloperreporting.php
@@ -49,6 +49,7 @@ class Playdeveloperreporting extends \Google\Service
   public $vitals_slowrenderingrate;
   public $vitals_slowstartrate;
   public $vitals_stuckbackgroundwakelockrate;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Playdeveloperreporting
@@ -62,6 +63,7 @@ class Playdeveloperreporting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://playdeveloperreporting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://playdeveloperreporting.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/PolicyAnalyzer.php
+++ b/src/PolicyAnalyzer.php
@@ -39,6 +39,7 @@ class PolicyAnalyzer extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $projects_locations_activityTypes_activities;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PolicyAnalyzer service.
@@ -51,6 +52,7 @@ class PolicyAnalyzer extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://policyanalyzer.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://policyanalyzer.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PolicySimulator.php
+++ b/src/PolicySimulator.php
@@ -59,6 +59,7 @@ class PolicySimulator extends \Google\Service
   public $projects_locations_replays;
   public $projects_locations_replays_operations;
   public $projects_locations_replays_results;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PolicySimulator service.
@@ -71,6 +72,7 @@ class PolicySimulator extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://policysimulator.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://policysimulator.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PolicyTroubleshooter.php
+++ b/src/PolicyTroubleshooter.php
@@ -39,6 +39,7 @@ class PolicyTroubleshooter extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $iam;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PolicyTroubleshooter service.
@@ -51,6 +52,7 @@ class PolicyTroubleshooter extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://policytroubleshooter.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://policytroubleshooter.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PostmasterTools.php
+++ b/src/PostmasterTools.php
@@ -42,6 +42,7 @@ class PostmasterTools extends \Google\Service
 
   public $domains;
   public $domains_trafficStats;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PostmasterTools service.
@@ -54,6 +55,7 @@ class PostmasterTools extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://gmailpostmastertools.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://gmailpostmastertools.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Pubsub.php
+++ b/src/Pubsub.php
@@ -47,6 +47,7 @@ class Pubsub extends \Google\Service
   public $projects_topics;
   public $projects_topics_snapshots;
   public $projects_topics_subscriptions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Pubsub service.
@@ -59,6 +60,7 @@ class Pubsub extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://pubsub.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://pubsub.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/PubsubLite.php
+++ b/src/PubsubLite.php
@@ -47,6 +47,7 @@ class PubsubLite extends \Google\Service
   public $cursor_projects_locations_subscriptions;
   public $cursor_projects_locations_subscriptions_cursors;
   public $topicStats_projects_locations_topics;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the PubsubLite service.
@@ -59,6 +60,7 @@ class PubsubLite extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://pubsublite.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://pubsublite.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/RealTimeBidding.php
+++ b/src/RealTimeBidding.php
@@ -49,6 +49,7 @@ class RealTimeBidding extends \Google\Service
   public $buyers;
   public $buyers_creatives;
   public $buyers_userLists;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the RealTimeBidding service.
@@ -61,6 +62,7 @@ class RealTimeBidding extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://realtimebidding.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://realtimebidding.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/RecaptchaEnterprise.php
+++ b/src/RecaptchaEnterprise.php
@@ -45,6 +45,7 @@ class RecaptchaEnterprise extends \Google\Service
   public $projects_relatedaccountgroupmemberships;
   public $projects_relatedaccountgroups;
   public $projects_relatedaccountgroups_memberships;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the RecaptchaEnterprise service.
@@ -57,6 +58,7 @@ class RecaptchaEnterprise extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://recaptchaenterprise.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://recaptchaenterprise.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/RecommendationsAI.php
+++ b/src/RecommendationsAI.php
@@ -51,6 +51,7 @@ class RecommendationsAI extends \Google\Service
   public $projects_locations_catalogs_eventStores_predictionApiKeyRegistrations;
   public $projects_locations_catalogs_eventStores_userEvents;
   public $projects_locations_catalogs_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the RecommendationsAI service.
@@ -63,6 +64,7 @@ class RecommendationsAI extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://recommendationengine.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://recommendationengine.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta1';

--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -52,6 +52,7 @@ class Recommender extends \Google\Service
   public $projects_locations_insightTypes_insights;
   public $projects_locations_recommenders;
   public $projects_locations_recommenders_recommendations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Recommender service.
@@ -64,6 +65,7 @@ class Recommender extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://recommender.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://recommender.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Reports.php
+++ b/src/Reports.php
@@ -48,6 +48,7 @@ class Reports extends \Google\Service
   public $customerUsageReports;
   public $entityUsageReports;
   public $userUsageReport;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Reports service.
@@ -60,6 +61,7 @@ class Reports extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://admin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://admin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'reports_v1';

--- a/src/Reseller.php
+++ b/src/Reseller.php
@@ -45,6 +45,7 @@ class Reseller extends \Google\Service
   public $customers;
   public $resellernotify;
   public $subscriptions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Reseller service.
@@ -57,6 +58,7 @@ class Reseller extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://reseller.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://reseller.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ResourceSettings.php
+++ b/src/ResourceSettings.php
@@ -43,6 +43,7 @@ class ResourceSettings extends \Google\Service
   public $folders_settings;
   public $organizations_settings;
   public $projects_settings;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ResourceSettings service.
@@ -55,6 +56,7 @@ class ResourceSettings extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://resourcesettings.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://resourcesettings.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/SASPortalTesting.php
+++ b/src/SASPortalTesting.php
@@ -61,6 +61,7 @@ class SASPortalTesting extends \Google\Service
   public $nodes_nodes_devices;
   public $nodes_nodes_nodes;
   public $policies;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SASPortalTesting service.
@@ -73,6 +74,7 @@ class SASPortalTesting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://prod-tt-sasportal.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://prod-tt-sasportal.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1alpha1';

--- a/src/SQLAdmin.php
+++ b/src/SQLAdmin.php
@@ -51,6 +51,7 @@ class SQLAdmin extends \Google\Service
   public $sslCerts;
   public $tiers;
   public $users;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SQLAdmin service.
@@ -63,6 +64,7 @@ class SQLAdmin extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://sqladmin.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://sqladmin.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Safebrowsing.php
+++ b/src/Safebrowsing.php
@@ -41,6 +41,7 @@ class Safebrowsing extends \Google\Service
 
 
   public $hashes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Safebrowsing service.
@@ -53,6 +54,7 @@ class Safebrowsing extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://safebrowsing.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://safebrowsing.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v5';

--- a/src/Sasportal.php
+++ b/src/Sasportal.php
@@ -61,6 +61,7 @@ class Sasportal extends \Google\Service
   public $nodes_nodes_devices;
   public $nodes_nodes_nodes;
   public $policies;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Sasportal service.
@@ -73,6 +74,7 @@ class Sasportal extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://sasportal.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://sasportal.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1alpha1';

--- a/src/Script.php
+++ b/src/Script.php
@@ -94,6 +94,7 @@ class Script extends \Google\Service
   public $projects_deployments;
   public $projects_versions;
   public $scripts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Script service.
@@ -106,6 +107,7 @@ class Script extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://script.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://script.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/SearchConsole.php
+++ b/src/SearchConsole.php
@@ -47,6 +47,7 @@ class SearchConsole extends \Google\Service
   public $sites;
   public $urlInspection_index;
   public $urlTestingTools_mobileFriendlyTest;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SearchConsole service.
@@ -59,6 +60,7 @@ class SearchConsole extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://searchconsole.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://searchconsole.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/SecretManager.php
+++ b/src/SecretManager.php
@@ -44,6 +44,7 @@ class SecretManager extends \Google\Service
   public $projects_locations_secrets_versions;
   public $projects_secrets;
   public $projects_secrets_versions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SecretManager service.
@@ -56,6 +57,7 @@ class SecretManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://secretmanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://secretmanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/SecurityCommandCenter.php
+++ b/src/SecurityCommandCenter.php
@@ -90,6 +90,7 @@ class SecurityCommandCenter extends \Google\Service
   public $projects_sources;
   public $projects_sources_findings;
   public $projects_sources_findings_externalSystems;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SecurityCommandCenter
@@ -103,6 +104,7 @@ class SecurityCommandCenter extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://securitycenter.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://securitycenter.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ServiceConsumerManagement.php
+++ b/src/ServiceConsumerManagement.php
@@ -41,6 +41,7 @@ class ServiceConsumerManagement extends \Google\Service
   public $operations;
   public $services;
   public $services_tenancyUnits;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceConsumerManagement
@@ -54,6 +55,7 @@ class ServiceConsumerManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://serviceconsumermanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://serviceconsumermanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ServiceControl.php
+++ b/src/ServiceControl.php
@@ -43,6 +43,7 @@ class ServiceControl extends \Google\Service
       "https://www.googleapis.com/auth/servicecontrol";
 
   public $services;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceControl service.
@@ -55,6 +56,7 @@ class ServiceControl extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://servicecontrol.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://servicecontrol.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/ServiceDirectory.php
+++ b/src/ServiceDirectory.php
@@ -43,6 +43,7 @@ class ServiceDirectory extends \Google\Service
   public $projects_locations_namespaces;
   public $projects_locations_namespaces_services;
   public $projects_locations_namespaces_services_endpoints;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceDirectory service.
@@ -55,6 +56,7 @@ class ServiceDirectory extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://servicedirectory.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://servicedirectory.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ServiceManagement.php
+++ b/src/ServiceManagement.php
@@ -54,6 +54,7 @@ class ServiceManagement extends \Google\Service
   public $services_configs;
   public $services_consumers;
   public $services_rollouts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceManagement service.
@@ -66,6 +67,7 @@ class ServiceManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://servicemanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://servicemanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ServiceNetworking.php
+++ b/src/ServiceNetworking.php
@@ -51,6 +51,7 @@ class ServiceNetworking extends \Google\Service
   public $services_projects_global_networks_dnsZones;
   public $services_projects_global_networks_peeredDnsDomains;
   public $services_roles;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceNetworking service.
@@ -63,6 +64,7 @@ class ServiceNetworking extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://servicenetworking.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://servicenetworking.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ServiceUsage.php
+++ b/src/ServiceUsage.php
@@ -48,6 +48,7 @@ class ServiceUsage extends \Google\Service
 
   public $operations;
   public $services;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ServiceUsage service.
@@ -60,6 +61,7 @@ class ServiceUsage extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://serviceusage.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://serviceusage.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Sheets.php
+++ b/src/Sheets.php
@@ -54,6 +54,7 @@ class Sheets extends \Google\Service
   public $spreadsheets_developerMetadata;
   public $spreadsheets_sheets;
   public $spreadsheets_values;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Sheets service.
@@ -66,6 +67,7 @@ class Sheets extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://sheets.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://sheets.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v4';

--- a/src/ShoppingContent.php
+++ b/src/ShoppingContent.php
@@ -80,6 +80,7 @@ class ShoppingContent extends \Google\Service
   public $settlementtransactions;
   public $shippingsettings;
   public $shoppingadsprogram;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ShoppingContent service.
@@ -92,6 +93,7 @@ class ShoppingContent extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://shoppingcontent.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://shoppingcontent.UNIVERSE_DOMAIN/';
     $this->servicePath = 'content/v2.1/';
     $this->batchPath = 'batch';
     $this->version = 'v2.1';

--- a/src/SiteVerification.php
+++ b/src/SiteVerification.php
@@ -42,6 +42,7 @@ class SiteVerification extends \Google\Service
       "https://www.googleapis.com/auth/siteverification.verify_only";
 
   public $webResource;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SiteVerification service.
@@ -54,6 +55,7 @@ class SiteVerification extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://www.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://www.UNIVERSE_DOMAIN/';
     $this->servicePath = 'siteVerification/v1/';
     $this->batchPath = 'batch/siteVerification/v1';
     $this->version = 'v1';

--- a/src/Slides.php
+++ b/src/Slides.php
@@ -58,6 +58,7 @@ class Slides extends \Google\Service
 
   public $presentations;
   public $presentations_pages;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Slides service.
@@ -70,6 +71,7 @@ class Slides extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://slides.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://slides.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/SmartDeviceManagement.php
+++ b/src/SmartDeviceManagement.php
@@ -42,6 +42,7 @@ class SmartDeviceManagement extends \Google\Service
   public $enterprises_devices;
   public $enterprises_structures;
   public $enterprises_structures_rooms;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the SmartDeviceManagement
@@ -55,6 +56,7 @@ class SmartDeviceManagement extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://smartdevicemanagement.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://smartdevicemanagement.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Spanner.php
+++ b/src/Spanner.php
@@ -63,6 +63,7 @@ class Spanner extends \Google\Service
   public $projects_instances_instancePartitions_operations;
   public $projects_instances_operations;
   public $scans;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Spanner service.
@@ -75,6 +76,7 @@ class Spanner extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://spanner.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://spanner.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Speech.php
+++ b/src/Speech.php
@@ -42,6 +42,7 @@ class Speech extends \Google\Service
   public $projects_locations_customClasses;
   public $projects_locations_phraseSets;
   public $speech;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Speech service.
@@ -54,6 +55,7 @@ class Speech extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://speech.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://speech.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -63,6 +63,7 @@ class Storage extends \Google\Service
   public $operations;
   public $projects_hmacKeys;
   public $projects_serviceAccount;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Storage service.
@@ -75,6 +76,7 @@ class Storage extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://storage.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://storage.UNIVERSE_DOMAIN/';
     $this->servicePath = 'storage/v1/';
     $this->batchPath = 'batch/storage/v1';
     $this->version = 'v1';

--- a/src/Storagetransfer.php
+++ b/src/Storagetransfer.php
@@ -43,6 +43,7 @@ class Storagetransfer extends \Google\Service
   public $projects_agentPools;
   public $transferJobs;
   public $transferOperations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Storagetransfer service.
@@ -55,6 +56,7 @@ class Storagetransfer extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://storagetransfer.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://storagetransfer.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/StreetViewPublish.php
+++ b/src/StreetViewPublish.php
@@ -44,6 +44,7 @@ class StreetViewPublish extends \Google\Service
   public $photoSequence;
   public $photoSequences;
   public $photos;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the StreetViewPublish service.
@@ -56,6 +57,7 @@ class StreetViewPublish extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://streetviewpublish.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://streetviewpublish.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/TPU.php
+++ b/src/TPU.php
@@ -44,6 +44,7 @@ class TPU extends \Google\Service
   public $projects_locations_operations;
   public $projects_locations_queuedResources;
   public $projects_locations_runtimeVersions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the TPU service.
@@ -56,6 +57,7 @@ class TPU extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://tpu.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://tpu.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/TagManager.php
+++ b/src/TagManager.php
@@ -74,6 +74,7 @@ class TagManager extends \Google\Service
   public $accounts_containers_workspaces_variables;
   public $accounts_containers_workspaces_zones;
   public $accounts_user_permissions;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the TagManager service.
@@ -86,6 +87,7 @@ class TagManager extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://tagmanager.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://tagmanager.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -43,6 +43,7 @@ class Tasks extends \Google\Service
 
   public $tasklists;
   public $tasks;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Tasks service.
@@ -55,6 +56,7 @@ class Tasks extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://tasks.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://tasks.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Testing.php
+++ b/src/Testing.php
@@ -46,6 +46,7 @@ class Testing extends \Google\Service
   public $projects_deviceSessions;
   public $projects_testMatrices;
   public $testEnvironmentCatalog;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Testing service.
@@ -58,6 +59,7 @@ class Testing extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://testing.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://testing.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Texttospeech.php
+++ b/src/Texttospeech.php
@@ -44,6 +44,7 @@ class Texttospeech extends \Google\Service
   public $projects_locations_operations;
   public $text;
   public $voices;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Texttospeech service.
@@ -56,6 +57,7 @@ class Texttospeech extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://texttospeech.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://texttospeech.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/ToolResults.php
+++ b/src/ToolResults.php
@@ -49,6 +49,7 @@ class ToolResults extends \Google\Service
   public $projects_histories_executions_steps_perfSampleSeries_samples;
   public $projects_histories_executions_steps_testCases;
   public $projects_histories_executions_steps_thumbnails;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the ToolResults service.
@@ -61,6 +62,7 @@ class ToolResults extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://toolresults.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://toolresults.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1beta3';

--- a/src/TrafficDirectorService.php
+++ b/src/TrafficDirectorService.php
@@ -39,6 +39,7 @@ class TrafficDirectorService extends \Google\Service
       "https://www.googleapis.com/auth/cloud-platform";
 
   public $discovery;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the TrafficDirectorService
@@ -52,6 +53,7 @@ class TrafficDirectorService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://trafficdirector.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://trafficdirector.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/Transcoder.php
+++ b/src/Transcoder.php
@@ -41,6 +41,7 @@ class Transcoder extends \Google\Service
 
   public $projects_locations_jobTemplates;
   public $projects_locations_jobs;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Transcoder service.
@@ -53,6 +54,7 @@ class Transcoder extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://transcoder.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://transcoder.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Translate.php
+++ b/src/Translate.php
@@ -53,6 +53,7 @@ class Translate extends \Google\Service
   public $projects_locations_glossaries_glossaryEntries;
   public $projects_locations_models;
   public $projects_locations_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Translate service.
@@ -65,6 +66,7 @@ class Translate extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://translation.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://translation.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/TravelImpactModel.php
+++ b/src/TravelImpactModel.php
@@ -37,6 +37,7 @@ class TravelImpactModel extends \Google\Service
 
 
   public $flights;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the TravelImpactModel service.
@@ -49,6 +50,7 @@ class TravelImpactModel extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://travelimpactmodel.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://travelimpactmodel.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/VMMigrationService.php
+++ b/src/VMMigrationService.php
@@ -52,6 +52,7 @@ class VMMigrationService extends \Google\Service
   public $projects_locations_sources_migratingVms_replicationCycles;
   public $projects_locations_sources_utilizationReports;
   public $projects_locations_targetProjects;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the VMMigrationService service.
@@ -64,6 +65,7 @@ class VMMigrationService extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://vmmigration.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://vmmigration.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Vault.php
+++ b/src/Vault.php
@@ -53,6 +53,7 @@ class Vault extends \Google\Service
   public $matters_holds_accounts;
   public $matters_savedQueries;
   public $operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Vault service.
@@ -65,6 +66,7 @@ class Vault extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://vault.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://vault.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Verifiedaccess.php
+++ b/src/Verifiedaccess.php
@@ -40,6 +40,7 @@ class Verifiedaccess extends \Google\Service
       "https://www.googleapis.com/auth/verifiedaccess";
 
   public $challenge;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Verifiedaccess service.
@@ -52,6 +53,7 @@ class Verifiedaccess extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://verifiedaccess.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://verifiedaccess.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/VersionHistory.php
+++ b/src/VersionHistory.php
@@ -40,6 +40,7 @@ class VersionHistory extends \Google\Service
   public $platforms_channels;
   public $platforms_channels_versions;
   public $platforms_channels_versions_releases;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the VersionHistory service.
@@ -52,6 +53,7 @@ class VersionHistory extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://versionhistory.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://versionhistory.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Vision.php
+++ b/src/Vision.php
@@ -57,6 +57,7 @@ class Vision extends \Google\Service
   public $projects_locations_products;
   public $projects_locations_products_referenceImages;
   public $projects_operations;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Vision service.
@@ -69,6 +70,7 @@ class Vision extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://vision.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://vision.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/WebRisk.php
+++ b/src/WebRisk.php
@@ -43,6 +43,7 @@ class WebRisk extends \Google\Service
   public $projects_submissions;
   public $threatLists;
   public $uris;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the WebRisk service.
@@ -55,6 +56,7 @@ class WebRisk extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://webrisk.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://webrisk.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Webfonts.php
+++ b/src/Webfonts.php
@@ -38,6 +38,7 @@ class Webfonts extends \Google\Service
 
 
   public $webfonts;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Webfonts service.
@@ -50,6 +51,7 @@ class Webfonts extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://webfonts.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://webfonts.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/WorkflowExecutions.php
+++ b/src/WorkflowExecutions.php
@@ -42,6 +42,7 @@ class WorkflowExecutions extends \Google\Service
   public $projects_locations_workflows_executions;
   public $projects_locations_workflows_executions_callbacks;
   public $projects_locations_workflows_executions_stepEntries;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the WorkflowExecutions service.
@@ -54,6 +55,7 @@ class WorkflowExecutions extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://workflowexecutions.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://workflowexecutions.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/Workflows.php
+++ b/src/Workflows.php
@@ -42,6 +42,7 @@ class Workflows extends \Google\Service
   public $projects_locations;
   public $projects_locations_operations;
   public $projects_locations_workflows;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the Workflows service.
@@ -54,6 +55,7 @@ class Workflows extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://workflows.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://workflows.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';

--- a/src/YouTube.php
+++ b/src/YouTube.php
@@ -88,6 +88,7 @@ class YouTube extends \Google\Service
   public $videos;
   public $watermarks;
   public $youtube_v3;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the YouTube service.
@@ -100,6 +101,7 @@ class YouTube extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://youtube.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://youtube.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v3';

--- a/src/YouTubeAnalytics.php
+++ b/src/YouTubeAnalytics.php
@@ -53,6 +53,7 @@ class YouTubeAnalytics extends \Google\Service
   public $groupItems;
   public $groups;
   public $reports;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the YouTubeAnalytics service.
@@ -65,6 +66,7 @@ class YouTubeAnalytics extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://youtubeanalytics.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://youtubeanalytics.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v2';

--- a/src/YouTubeReporting.php
+++ b/src/YouTubeReporting.php
@@ -46,6 +46,7 @@ class YouTubeReporting extends \Google\Service
   public $jobs_reports;
   public $media;
   public $reportTypes;
+  public $rootUrlTemplate;
 
   /**
    * Constructs the internal representation of the YouTubeReporting service.
@@ -58,6 +59,7 @@ class YouTubeReporting extends \Google\Service
   {
     parent::__construct($clientOrConfig);
     $this->rootUrl = $rootUrl ?: 'https://youtubereporting.googleapis.com/';
+    $this->rootUrlTemplate = $rootUrl ?: 'https://youtubereporting.UNIVERSE_DOMAIN/';
     $this->servicePath = '';
     $this->batchPath = 'batch';
     $this->version = 'v1';


### PR DESCRIPTION
adds new `$rootUrlTemplate` property to all service classes in order to support the universe domain option in https://github.com/googleapis/google-api-php-client/pull/2563  