### PR TITLE
fix: broken codegen workflow

### DIFF
--- a/generator/setup.py
+++ b/generator/setup.py
@@ -44,5 +44,6 @@ setup(
                       'httplib2',
                       'absl-py',
                       'six',
-                      'python-gflags'],
+                      'python-gflags',
+                      'setuptools'],
     zip_safe=False)


### PR DESCRIPTION
fixes https://github.com/googleapis/google-api-php-client-services/issues/6672

Codegen broke in https://github.com/googleapis/google-api-php-client-services/pull/6346 because Python 3.13 does not include `distutils`, and instead requires the installation of `setuptools`

See https://github.com/googleapis/google-api-php-client-services/actions/runs/17654148210/job/50172447288