### PR TITLE
feat: use hashed filename for classnames which are 140 characters or more

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -40,7 +40,7 @@ spl_autoload_register(function ($class) {
         $relativeClass = substr($class, strlen('Google\\Service\\'));
         $parts = explode('\\', $relativeClass);
         $leaf = array_pop($parts);
-        if (strlen($leaf) > 90) {
+        if (strlen($leaf) > 139) {
             $shortenedLeaf = substr($leaf, 0, 80) . '_' . strtoupper(substr(md5($leaf), 0, 8));
             $subPath = implode('/', $parts);
             $filePath = __DIR__ . '/src/' . ($subPath ? $subPath . '/' : '') . $shortenedLeaf . '.php';

--- a/autoload.php
+++ b/autoload.php
@@ -34,3 +34,21 @@ spl_autoload_register(function ($class) {
         }
     }
 }, true, true);
+
+spl_autoload_register(function ($class) {
+    if (0 === strpos($class, 'Google\\Service\\')) {
+        $relativeClass = substr($class, strlen('Google\\Service\\'));
+        $parts = explode('\\', $relativeClass);
+        $leaf = array_pop($parts);
+        if (strlen($leaf) > 90) {
+            $shortenedLeaf = substr($leaf, 0, 80) . '_' . strtoupper(substr(md5($leaf), 0, 8));
+            $subPath = implode('/', $parts);
+            $filePath = __DIR__ . '/src/' . ($subPath ? $subPath . '/' : '') . $shortenedLeaf . '.php';
+            if (file_exists($filePath)) {
+                require_once $filePath;
+                return true;
+            }
+        }
+    }
+}, true, true);
+

--- a/autoload.php
+++ b/autoload.php
@@ -32,11 +32,7 @@ spl_autoload_register(function ($class) {
         if ($classExists) {
             return true;
         }
-    }
-}, true, true);
-
-spl_autoload_register(function ($class) {
-    if (0 === strpos($class, 'Google\\Service\\')) {
+    } elseif (0 === strpos($class, 'Google\\Service\\')) {
         $relativeClass = substr($class, strlen('Google\\Service\\'));
         $parts = explode('\\', $relativeClass);
         $leaf = array_pop($parts);

--- a/generator/src/googleapis/codegen/php_generator.py
+++ b/generator/src/googleapis/codegen/php_generator.py
@@ -28,8 +28,10 @@ Features:
 __author__ = 'chirags@google.com (Chirag Shah)'
 
 import collections
+import hashlib
 import json
 import operator
+import os
 
 from googleapis.codegen import api
 from googleapis.codegen import api_library_generator
@@ -52,6 +54,25 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
     super(PHPGenerator, self).__init__(PHPApi, discovery, 'php',
                                        language_model=PhpLanguageModel(),
                                        options=options)
+
+  def _GetOutputFilePath(self, output_path):
+    """Shortens the output path if the filename component is too long."""
+    directory, filename = os.path.split(output_path)
+    if filename.endswith('.php'):
+      classname, ext = os.path.splitext(filename)
+      if len(classname) > 90:
+        md5_hash = hashlib.md5(classname.encode('utf-8')).hexdigest().upper()[:8]
+        shortened_classname = '%s_%s' % (classname[:80], md5_hash)
+        filename = shortened_classname + ext
+        return os.path.join(directory, filename)
+    return output_path
+
+  def RenderTemplateToFile(self, template_path, context_dict, package,
+                           output_path):
+    """Override to shorten long output paths."""
+    shortened_path = self._GetOutputFilePath(output_path)
+    super(PHPGenerator, self).RenderTemplateToFile(
+        template_path, context_dict, package, shortened_path)
 
   def AnnotateResource(self, the_api, resource):
     """Add the discovery dictionary as data to each resource.

--- a/generator/src/googleapis/codegen/php_generator.py
+++ b/generator/src/googleapis/codegen/php_generator.py
@@ -60,7 +60,7 @@ class PHPGenerator(api_library_generator.ApiLibraryGenerator):
     directory, filename = os.path.split(output_path)
     if filename.endswith('.php'):
       classname, ext = os.path.splitext(filename)
-      if len(classname) > 90:
+      if len(classname) > 139:
         md5_hash = hashlib.md5(classname.encode('utf-8')).hexdigest().upper()[:8]
         shortened_classname = '%s_%s' % (classname[:80], md5_hash)
         filename = shortened_classname + ext

--- a/generator/src/googleapis/codegen/php_generator_test.py
+++ b/generator/src/googleapis/codegen/php_generator_test.py
@@ -18,6 +18,8 @@ __author__ = 'chirags@google.com (Chirag Shah)'
 
 
 
+import hashlib
+
 from absl.testing import absltest
 from googleapis.codegen import api
 from googleapis.codegen import php_generator
@@ -138,6 +140,27 @@ class PHPApiTest(absltest.TestCase):
       s = schema_obj[1]
       self.assertEqual(php_type,
                         self.language_model.GetCodeTypeFromDictionary(s))
+
+  def testGetOutputFilePath(self):
+    # Standard path
+    path = 'Speech/SomeModel.php'
+    self.assertEqual(path, self.generator._GetOutputFilePath(path))
+
+    # Long class name (90 chars) - should not be shortened
+    classname_90 = 'A' * 90
+    path_90 = 'Speech/%s.php' % classname_90
+    self.assertEqual(path_90, self.generator._GetOutputFilePath(path_90))
+
+    # Long class name (91 chars) - should be shortened
+    classname_91 = 'A' * 91
+    expected_hash = hashlib.md5(classname_91.encode('utf-8')).hexdigest().upper()[:8]
+    expected_classname = 'A' * 80 + '_' + expected_hash
+    expected_path = 'Speech/%s.php' % expected_classname
+    self.assertEqual(expected_path, self.generator._GetOutputFilePath('Speech/%s.php' % classname_91))
+
+    # Path without .php extension (should not be shortened even if long)
+    long_txt = 'A' * 100
+    self.assertEqual('Speech/%s.txt' % long_txt, self.generator._GetOutputFilePath('Speech/%s.txt' % long_txt))
 
 if __name__ == '__main__':
   absltest.main()

--- a/generator/src/googleapis/codegen/php_generator_test.py
+++ b/generator/src/googleapis/codegen/php_generator_test.py
@@ -146,20 +146,20 @@ class PHPApiTest(absltest.TestCase):
     path = 'Speech/SomeModel.php'
     self.assertEqual(path, self.generator._GetOutputFilePath(path))
 
-    # Long class name (90 chars) - should not be shortened
-    classname_90 = 'A' * 90
-    path_90 = 'Speech/%s.php' % classname_90
-    self.assertEqual(path_90, self.generator._GetOutputFilePath(path_90))
+    # Long class name (139 chars) - should not be shortened
+    classname_139 = 'A' * 139
+    path_139 = 'Speech/%s.php' % classname_139
+    self.assertEqual(path_139, self.generator._GetOutputFilePath(path_139))
 
-    # Long class name (91 chars) - should be shortened
-    classname_91 = 'A' * 91
-    expected_hash = hashlib.md5(classname_91.encode('utf-8')).hexdigest().upper()[:8]
+    # Long class name (140 chars) - should be shortened
+    classname_140 = 'A' * 140
+    expected_hash = hashlib.md5(classname_140.encode('utf-8')).hexdigest().upper()[:8]
     expected_classname = 'A' * 80 + '_' + expected_hash
     expected_path = 'Speech/%s.php' % expected_classname
-    self.assertEqual(expected_path, self.generator._GetOutputFilePath('Speech/%s.php' % classname_91))
+    self.assertEqual(expected_path, self.generator._GetOutputFilePath('Speech/%s.php' % classname_140))
 
     # Path without .php extension (should not be shortened even if long)
-    long_txt = 'A' * 100
+    long_txt = 'A' * 150
     self.assertEqual('Speech/%s.txt' % long_txt, self.generator._GetOutputFilePath('Speech/%s.txt' % long_txt))
 
 if __name__ == '__main__':

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -62,14 +62,20 @@ class ServiceTest extends TestCase
     $classes[] = 'Google\Service\\' . $service;
     $classes[] = 'Google_Service_' . $service; // legacy name
     foreach (glob(__DIR__ . "/../src/$service/*.php") as $file) {
-      $className = basename($file, '.php');
-      $classes[] = "Google\Service\\$service\\" . $className;
-      $classes[] = "Google_Service_{$service}_" . $className; // legacy name
+      $content = file_get_contents($file);
+      if (preg_match('/^\s*class\s+(\w+)/m', $content, $matches)) {
+        $className = $matches[1];
+        $classes[] = "Google\\Service\\$service\\" . $className;
+        $classes[] = "Google_Service_{$service}_" . $className; // legacy name
+      }
     }
     foreach (glob(__DIR__ . "/../src/$service/Resource/*.php") as $file) {
-      $className = basename($file, '.php');
-      $classes[] = "Google\Service\\$service\Resource\\" . $className;
-      $classes[] = "Google_Service_{$service}_Resource_" . $className; // legacy name
+      $content = file_get_contents($file);
+      if (preg_match('/^\s*class\s+(\w+)/m', $content, $matches)) {
+        $className = $matches[1];
+        $classes[] = "Google\\Service\\$service\\Resource\\" . $className;
+        $classes[] = "Google_Service_{$service}_Resource_" . $className; // legacy name
+      }
     }
 
     return $classes;


### PR DESCRIPTION
Currently we are having issues with the discovery document and our generator creating overly long file names. This has caused some issues on some environments as they tend to have a limit on how long a file name can be.

This aims to reduce the size of the file name without altering the name of the class itself to avoid breaking compatibility.

The decided algorithm is:
`classname[:80]_md5(classname).php`