### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -23,9 +23,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         fetch-depth: '0'
+        persist-credentials: false
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
@@ -33,7 +34,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         default_bump: minor
     - name: Create a GitHub release
-      uses: actions/create-release@v1
+      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   schedule:
     # daily at 12:30 am
@@ -14,7 +17,7 @@ jobs:
     outputs:
       services: ${{ steps.chunk.outputs.result }}
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: chunk
         with:
           script: |
@@ -40,25 +43,34 @@ jobs:
       matrix:
         service: ${{fromJson(needs.batch.outputs.services).one}}
     steps:
-      - run: echo generating ${{ matrix.service }}
-      - uses: actions/checkout@v7
+      - run: echo generating ${MATRIX_SERVICE}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
           path: google-api-php-client-services
-      - uses: actions/checkout@v7
+          persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - id: find-preferred-versions
         run: |
-          versions=$( cat discovery-artifact-manager/discoveries/index.json | jq -r '[.items[] | select(.name == "${{ matrix.service }}") | select(.name == "admin" or .preferred).version] | join(",")' )
+          versions=$( cat discovery-artifact-manager/discoveries/index.json | jq -r '[.items[] | select(.name == "${MATRIX_SERVICE}") | select(.name == "admin" or .preferred).version] | join(",")' )
           echo "::set-output name=versions::$versions"
-      - run: ./google-api-php-client-services/.github/workflows/generate.sh ${{ matrix.service }} ${{ steps.find-preferred-versions.outputs.versions }}
-      - uses: googleapis/code-suggester@v5
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - run: ./google-api-php-client-services/.github/workflows/generate.sh ${MATRIX_SERVICE} ${STEPS_FIND_PREFERRED_VERSIONS_OUTPUTS_VERSIONS}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+          STEPS_FIND_PREFERRED_VERSIONS_OUTPUTS_VERSIONS: ${{ steps.find-preferred-versions.outputs.versions }}
+      - uses: googleapis/code-suggester@f9fef85aa02459e30e62526abe950341cbbd768b # v5
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
         with:
@@ -83,25 +95,34 @@ jobs:
       matrix:
         service: ${{fromJson(needs.batch.outputs.services).two}}
     steps:
-      - run: echo generating ${{ matrix.service }}
-      - uses: actions/checkout@v7
+      - run: echo generating ${MATRIX_SERVICE}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
           path: google-api-php-client-services
-      - uses: actions/checkout@v7
+          persist-credentials: false
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: googleapis/discovery-artifact-manager
           fetch-depth: 1
           path: discovery-artifact-manager
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
       - id: find-preferred-versions
         run: |
-          versions=$( cat discovery-artifact-manager/discoveries/index.json | jq -r '[.items[] | select(.name == "${{ matrix.service }}") | select(.name == "admin" or .preferred).version] | join(",")' )
+          versions=$( cat discovery-artifact-manager/discoveries/index.json | jq -r '[.items[] | select(.name == "${MATRIX_SERVICE}") | select(.name == "admin" or .preferred).version] | join(",")' )
           echo "::set-output name=versions::$versions"
-      - run: ./google-api-php-client-services/.github/workflows/generate.sh ${{ matrix.service }} ${{ steps.find-preferred-versions.outputs.versions }}
-      - uses: googleapis/code-suggester@v5
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+      - run: ./google-api-php-client-services/.github/workflows/generate.sh ${MATRIX_SERVICE} ${STEPS_FIND_PREFERRED_VERSIONS_OUTPUTS_VERSIONS}
+        env:
+          MATRIX_SERVICE: ${{ matrix.service }}
+          STEPS_FIND_PREFERRED_VERSIONS_OUTPUTS_VERSIONS: ${{ steps.find-preferred-versions.outputs.versions }}
+      - uses: googleapis/code-suggester@f9fef85aa02459e30e62526abe950341cbbd768b # v5
         env:
           ACCESS_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
         with:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -10,7 +10,7 @@ on:
 name: codegen
 jobs:
   discovery:
-    uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master
+    uses: googleapis/discovery-artifact-manager/.github/workflows/list-services.yml@master # zizmor: ignore[unpinned-uses]
   batch:
     runs-on: ubuntu-24.04
     needs: discovery

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -19,10 +19,12 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: chunk
+        env:
+          SERVICES_LIST: ${{ needs.discovery.outputs.services }}
         with:
           script: |
             console.log('splitting service names list into batches')
-            const services = ${{ needs.discovery.outputs.services }}
+            const services = JSON.parse(process.env.SERVICES_LIST)
             const result = {
               "one": [],
               "two": [],

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
     docs:
         name: "Generate and Deploy Documentation"
-        uses: GoogleCloudPlatform/php-tools/.github/workflows/doctum.yml@main
+        uses: GoogleCloudPlatform/php-tools/.github/workflows/doctum.yml@main # zizmor: ignore[unpinned-uses]
         with:
           title: "Google Cloud PHP Client Services"
           # use a custom theme so that namespaces that share the same name as classes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 name: Test Suite
 on:
   push:
@@ -17,13 +20,15 @@ jobs:
                     php: "8.1"
         name: PHP ${{matrix.php }} Unit Test
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
               with:
                 php-version: ${{ matrix.php }}
             - name: Install Dependencies
-              uses: nick-invision/retry@v4
+              uses: nick-invision/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
               with:
                 timeout_minutes: 10
                 max_attempts: 3
@@ -34,9 +39,11 @@ jobs:
         runs-on: ubuntu-24.04
         name: Generator Unit Tests
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
             - name: Set up Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
               with:
                 python-version: "3.14"
             - name: Install dependencies
@@ -53,9 +60,11 @@ jobs:
                 php: [ "8.1" ]
         name: Casing Conflict Test
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
               with:
                 php-version: ${{ matrix.php }}
             - name: Run Script

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:best-practices"
   ],
   "pinVersions": false,
   "rebaseStalePrs": true


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
